### PR TITLE
Add CDS Services option to application settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
       "./tests/jest-setup.js"
     ],
     "moduleNameMapper": {
-      "\\.(jpg|jpeg|png|svg)$": "<rootDir>/src/assets/__mocks__/fileMock.js",
+      "\\.(jpg|jpeg|png|svg|pem)$": "<rootDir>/src/assets/__mocks__/fileMock.js",
       "\\.(css|scss)$": "identity-obj-proxy"
     },
     "coveragePathIgnorePatterns": [

--- a/src/components/BaseEntryBody/base-entry-body.jsx
+++ b/src/components/BaseEntryBody/base-entry-body.jsx
@@ -8,26 +8,37 @@ import styles from './base-entry-body.css';
 const BaseEntryBody = ({
   currentFhirServer, formFieldLabel, shouldDisplayError,
   errorMessage, placeholderText, inputOnChange, inputName,
-}) => (
-  <div className={styles.container}>
-    <Text weight={400} fontSize={16}>Current FHIR server</Text><br />
-    <Text weight={200} fontSize={14}>{currentFhirServer}</Text>
-    <div className={styles['vertical-separation']}>
-      <Field
-        label={formFieldLabel}
-        isInvalid={shouldDisplayError}
-        error={errorMessage}
-        required
-      >
-        <Input
-          name={inputName}
-          placeholder={placeholderText}
-          onChange={inputOnChange}
+}) => {
+  let fhirServerDisplay;
+  if (currentFhirServer) {
+    fhirServerDisplay = (
+      <div>
+        <Text weight={400} fontSize={16}>Current FHIR server</Text><br />
+        <Text weight={200} fontSize={14}>{currentFhirServer}</Text>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.container}>
+      {fhirServerDisplay}
+      <div className={styles['vertical-separation']}>
+        <Field
+          label={formFieldLabel}
+          isInvalid={shouldDisplayError}
+          error={errorMessage}
           required
-        />
-      </Field>
+        >
+          <Input
+            name={inputName}
+            placeholder={placeholderText}
+            onChange={inputOnChange}
+            required
+          />
+        </Field>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default BaseEntryBody;

--- a/src/components/Header/header.jsx
+++ b/src/components/Header/header.jsx
@@ -11,6 +11,7 @@ import Button from 'terra-button';
 import IconLeft from 'terra-icon/lib/icon/IconLeft';
 import IconEdit from 'terra-icon/lib/icon/IconEdit';
 
+import ServicesEntry from '../ServicesEntry/services-entry';
 import PatientEntry from '../PatientEntry/patient-entry';
 import FhirServerEntry from '../FhirServerEntry/fhir-server-entry';
 
@@ -28,6 +29,7 @@ export class Header extends Component {
       settingsOpen: false,
       isChangePatientOpen: false,
       isChangeFhirServerOpen: false,
+      isAddServicesOpen: false,
     };
 
     this.switchHook = this.switchHook.bind(this);
@@ -37,7 +39,8 @@ export class Header extends Component {
 
     this.openSettingsMenu = this.openSettingsMenu.bind(this);
     this.closeSettingsMenu = this.closeSettingsMenu.bind(this);
-    this.addCDSServices = this.addCDSServices.bind(this);
+    this.openAddServices = this.openAddServices.bind(this);
+    this.closeAddServices = this.closeAddServices.bind(this);
     this.openChangePatient = this.openChangePatient.bind(this);
     this.closeChangePatient = this.closeChangePatient.bind(this);
     this.openChangeFhirServer = this.openChangeFhirServer.bind(this);
@@ -61,10 +64,13 @@ export class Header extends Component {
 
   switchHook(hook) { this.props.setHook(hook); }
 
-  addCDSServices() {
-    // TODO: Prompt user to add CDS Service Endpoint
-    this.closeSettingsMenu();
+  openAddServices() {
+    this.setState({ isAddServicesOpen: true });
+    if (this.state.settingsOpen) {
+      this.closeSettingsMenu();
+    }
   }
+  closeAddServices() { this.setState({ isAddServicesOpen: false }); }
 
   async openChangePatient(e, testCurrentPatient) {
     if (testCurrentPatient) {
@@ -96,7 +102,7 @@ export class Header extends Component {
         targetRef={this.getSettingsNode}
         isArrowDisplayed
       >
-        <Menu.Item text="Add CDS Services (placeholder)" key="add-services" onClick={this.addCDSServices} />
+        <Menu.Item text="Add CDS Services" key="add-services" onClick={this.openAddServices} />
         <Menu.Item text="Change Patient" key="change-patient" onClick={this.openChangePatient} />
         <Menu.Item text="Change FHIR Server" key="change-fhir-server" onClick={this.openChangeFhirServer} />
       </Menu>);
@@ -135,6 +141,10 @@ export class Header extends Component {
           style={{ backgroundColor: '#384e77' }}
         />
         {gearMenu}
+        {this.state.isAddServicesOpen ? <ServicesEntry
+          isOpen={this.state.isAddServicesOpen}
+          closePrompt={this.closeAddServices}
+        /> : null}
         {this.state.isChangePatientOpen ? <PatientEntry
           isOpen={this.state.isChangePatientOpen}
           closePrompt={this.closeChangePatient}

--- a/src/components/PatientView/patient-view.jsx
+++ b/src/components/PatientView/patient-view.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import cx from 'classnames';
 import pickBy from 'lodash/pickBy';
 import forIn from 'lodash/forIn';
+import isEqual from 'lodash/isEqual';
 
 import Card from '../Card/card';
 import styles from './patient-view.css';
@@ -20,7 +21,9 @@ export class PatientView extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.patient !== prevProps.patient || this.props.fhirServer !== prevProps.fhirServer) {
+    if (this.props.patient !== prevProps.patient ||
+        this.props.fhirServer !== prevProps.fhirServer ||
+        !isEqual(this.props.services, prevProps.services)) {
       this.executeRequests();
     }
   }

--- a/src/components/ServicesEntry/services-entry.css
+++ b/src/components/ServicesEntry/services-entry.css
@@ -1,0 +1,10 @@
+.right-align {
+  text-align: right;
+}
+
+@media screen and (min-width: 48em) {
+  .fixed-size {
+    height: 75%;
+    width: 100%;
+  }
+}

--- a/src/components/ServicesEntry/services-entry.jsx
+++ b/src/components/ServicesEntry/services-entry.jsx
@@ -21,7 +21,7 @@ export class ServicesEntry extends Component {
     super(props);
 
     this.state = {
-      isOpen: this.props.isOpen,
+      isOpen: props.isOpen,
       userInput: '',
       shouldDisplayError: false,
       errorMessage: '',
@@ -100,7 +100,7 @@ export class ServicesEntry extends Component {
             onClose={this.handleCloseModal}
           >
             <BaseEntryBody
-              formFieldLabel="Enter Discovery Endpoint URL"
+              formFieldLabel="Enter discovery endpoint url"
               shouldDisplayError={this.state.shouldDisplayError}
               errorMessage={this.state.errorMessage}
               placeholderText="https://example-services.com/cds-services"

--- a/src/components/ServicesEntry/services-entry.jsx
+++ b/src/components/ServicesEntry/services-entry.jsx
@@ -1,0 +1,128 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import Modal from 'terra-modal';
+import Button from 'terra-button';
+import Dialog from 'terra-dialog';
+import Spacer from 'terra-spacer';
+import Text from 'terra-text';
+
+import styles from './services-entry.css';
+import BaseEntryBody from '../BaseEntryBody/base-entry-body';
+import retrieveDiscoveryServices from '../../retrieve-data-helpers/discovery-services-retrieval';
+
+const propTypes = {
+  isOpen: PropTypes.bool,
+  closePrompt: PropTypes.func,
+};
+
+export class ServicesEntry extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isOpen: this.props.isOpen,
+      userInput: '',
+      shouldDisplayError: false,
+      errorMessage: '',
+    };
+
+    this.handleCloseModal = this.handleCloseModal.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.isOpen !== nextProps.isOpen) {
+      this.setState({ isOpen: nextProps.isOpen });
+    }
+  }
+
+  handleCloseModal() {
+    this.setState({ isOpen: false, shouldDisplayError: false, errorMessage: '' });
+    if (this.props.closePrompt) { this.props.closePrompt(); }
+  }
+
+  handleChange(e) {
+    this.setState({ userInput: e.target.value });
+  }
+
+  async handleSubmit() {
+    if (this.state.userInput === '' || !this.state.userInput || !this.state.userInput.trim()) {
+      this.setState({ shouldDisplayError: true, errorMessage: 'Enter a valid discovery endpoint' });
+    }
+    let checkUrl = this.state.userInput.trim();
+    if (!/^(https?:)?\/\//i.test(checkUrl)) {
+      checkUrl = `http://${checkUrl}`;
+      this.setState({
+        userInput: checkUrl,
+      });
+    }
+    try {
+      await retrieveDiscoveryServices(checkUrl).then(() => {
+        this.handleCloseModal();
+      });
+    } catch (e) {
+      this.setState({
+        shouldDisplayError: true,
+        errorMessage: 'Failed to connect to the discovery endpoint. See console for details.',
+      });
+    }
+  }
+
+  render() {
+    const headerContainer = (
+      <Text weight={700} fontSize={20}>Add CDS Services</Text>
+    );
+
+    const footerContainer = (
+      <div className={styles['right-align']}>
+        <Button text="Save" variant="emphasis" onClick={this.handleSubmit} />
+        <Spacer marginLeft="small" isInlineBlock>
+          <Button text="Cancel" onClick={this.handleCloseModal} />
+        </Spacer>
+      </div>
+    );
+
+    return (
+      <div>
+        <Modal
+          ariaLabel="CDS Services"
+          isOpen={this.state.isOpen}
+          closeOnEsc
+          closeOnOutsideClick
+          onRequestClose={this.handleCloseModal}
+          classNameModal={styles['fixed-size']}
+        >
+          <Dialog
+            header={headerContainer}
+            footer={footerContainer}
+            onClose={this.handleCloseModal}
+          >
+            <BaseEntryBody
+              formFieldLabel="Enter Discovery Endpoint URL"
+              shouldDisplayError={this.state.shouldDisplayError}
+              errorMessage={this.state.errorMessage}
+              placeholderText="https://example-services.com/cds-services"
+              inputOnChange={this.handleChange}
+              inputName="discovery-endpoint-input"
+            />
+            <Text isItalic>Note: See&nbsp;
+              <a
+                href="http://cds-hooks.org/specification/1.0/#discovery"
+                rel="noreferrer noopener"
+                target="_blank"
+              >
+                documentation
+              </a>&nbsp;for more details regarding the Discovery endpoint.
+            </Text>
+          </Dialog>
+        </Modal>
+      </div>
+    );
+  }
+}
+
+ServicesEntry.propTypes = propTypes;
+
+export default ServicesEntry;

--- a/src/reducers/service-exchange-reducers.js
+++ b/src/reducers/service-exchange-reducers.js
@@ -17,9 +17,6 @@ const serviceExchangeReducers = (state = initialState, action) => {
           service.responseStatus = action.responseStatus;
           const exchanges = Object.assign({}, state.exchanges);
           exchanges[action.url] = service;
-          if (state.selectedService) {
-            return Object.assign({}, state, { exchanges });
-          }
           return Object.assign({}, state, { selectedService: action.url, exchanges });
         }
         break;

--- a/tests/components/BaseEntryBody/base-entry-body.test.js
+++ b/tests/components/BaseEntryBody/base-entry-body.test.js
@@ -39,4 +39,15 @@ describe('BaseEntryBody component', () => {
     wrapper.find('Input').simulate('change', {'target': {'value': 'test'}});
     expect(inputOnChange).toHaveBeenCalled();
   });
+
+  it('should not render text displaying the current fhir server if the prop is not passed in', () => {
+    wrapper = shallow(<BaseEntryBody formFieldLabel={formFieldLabel} 
+      shouldDisplayError={shouldDisplayError} 
+      errorMessage={errorMessage} 
+      placeholderText={placeholderText} 
+      inputOnChange={inputOnChange} 
+      inputName={inputName} />);
+
+    expect(wrapper.find('Text').length).toEqual(0);
+  });
 });

--- a/tests/components/Header/header.test.js
+++ b/tests/components/Header/header.test.js
@@ -85,4 +85,17 @@ describe('Header component', () => {
       expect(shallowedComponent.find('Connect(FhirServerEntry)').length).toEqual(1);
     });
   });
+
+  describe('Add Services', () => {
+    beforeEach(() => {
+      shallowedComponent.childAt(0).dive().find('.icon').first().simulate('click');
+    });
+
+    it('should open the modal to add CDS Services if the Add Services option is clicked directly', () => {
+      shallowedComponent.find('Menu').childAt(0).simulate('click');
+      expect(shallowedComponent.state('isAddServicesOpen')).toBeTruthy();
+      expect(shallowedComponent.state('settingsOpen')).toBeFalsy();
+      expect(shallowedComponent.find('ServicesEntry').length).toEqual(1);
+    });
+  });
 });

--- a/tests/components/PatientView/patient-view.test.js
+++ b/tests/components/PatientView/patient-view.test.js
@@ -67,7 +67,10 @@ describe('PatientView component', () => {
 
   it('contains relevant messages for missing patient in context', () => {
     storeState = {
-      hookState: { isContextVisible: true },
+      hookState: { 
+        currentHook: 'patient-view',
+        isContextVisible: true 
+      },
       patientState: {
         currentPatient: {}
       },

--- a/tests/components/ServicesEntry/services-entry.test.js
+++ b/tests/components/ServicesEntry/services-entry.test.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import { mount, shallow } from 'enzyme';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+
+describe('FhirServerEntry component', () => {
+  let ServicesEntryView;
+  let mockSpy;
+  console.error = jest.fn();
+
+  function setup() {
+    jest.setMock('../../../src/retrieve-data-helpers/discovery-services-retrieval', mockSpy);
+    ServicesEntryView = require('../../../src/components/ServicesEntry/services-entry').default;
+  }
+
+  beforeEach(() => {
+    mockSpy = jest.fn(() => Promise.resolve(1));
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('changes isOpen state property if props changes for the property', () => {
+    setup();
+    let component = mount(<ServicesEntryView isOpen={false} />);
+    expect(component.prop('isOpen')).toEqual(false);
+    component.setProps({ isOpen: true });
+    expect(component.prop('isOpen')).toEqual(true);
+  });
+
+  it('handles closing the modal in the component', async () => {
+    setup();
+    let component = mount(<ServicesEntryView isOpen={true} />);
+    await component.find('.right-align').find('Button').at(1).simulate('click');
+    expect(component.state('isOpen')).toEqual(false);
+  });
+
+  describe('User input', () => {
+    const enterInputAndSave = (shallowedComponent, input) => {
+      shallowedComponent.find('BaseEntryBody').dive().find('Input').simulate('change', {'target': {'value': input}});
+      shallowedComponent.find('Dialog').dive().find('ContentContainer').dive().find('.right-align').find('Button').at(0).simulate('click');
+    };
+
+    it('displays an error if input is empty', () => {
+      mockSpy = jest.fn(() => { Promise.resolve(1) });
+      setup();
+      let component = shallow(<ServicesEntryView isOpen={true} />)
+      enterInputAndSave(component, '');
+      expect(component.state('shouldDisplayError')).toEqual(true);
+      expect(component.state('errorMessage')).not.toEqual('');
+    });
+
+    it('displays an error message if retrieving discovery endpoint fails', () => {
+      mockSpy = jest.fn(() => { throw new Error(1); });
+      setup();
+      let component = shallow(<ServicesEntryView isOpen={true} />)
+      enterInputAndSave(component, 'test');
+      expect(component.state('shouldDisplayError')).toEqual(true);
+      expect(component.state('errorMessage')).not.toEqual('');
+    });
+
+    it('closes the modal, resolves passed in prop promise if applicable, and closes prompt if possible', async () => {
+      const closePromptSpy = jest.fn();
+      setup();
+      let component = shallow(<ServicesEntryView isOpen={true} closePrompt={closePromptSpy} />)
+      await enterInputAndSave(component, 'https://test.com');
+      expect(component.state('shouldDisplayError')).toEqual(false);
+      expect(component.state('isOpen')).toEqual(false);
+      expect(closePromptSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/reducers/service-exchange-reducers.test.js
+++ b/tests/reducers/service-exchange-reducers.test.js
@@ -43,22 +43,6 @@ describe('Services Exchange Reducers', () => {
       });
       expect(reducer(state, action)).toEqual(newState);
     });
-
-    it('should store the request/response of an exchange and not set selectedService if set already', () => {
-      const action = Object.assign({
-        type: types.STORE_SERVICE_EXCHANGE,
-        url: 'http://example.com/cds-services/id-2'
-      }, storedExchange);
-
-      state = { selectedService: url, exchanges: {} };
-
-      const newState = Object.assign({}, state, {
-        exchanges: {
-          [action.url]: storedExchange
-        }
-      });
-      expect(reducer(state, action)).toEqual(newState);
-    });
   });
 
   describe('SELECT_SERVICE_CONTEXT', () => {


### PR DESCRIPTION
Currently, the Sandbox supports the ability to add CDS Services to test on the Sandbox, via "Add CDS Services" button. This 2.0 sandbox should be able to support this same functionality on the utilities drop down menu. When the "Add CDS Services" menu option is clicked, a modal appears that allows users to input their discovery endpoints and goes through validation before the services are configured on the app (and stored in state). This validation makes sure that a response is received by the discovery endpoint and that there is at least 1 service to configure onto the Sandbox.

@kpshek 