### PR TITLE
Add suggestion support and medication prescribe service triggers

### DIFF
--- a/src/actions/action-types.js
+++ b/src/actions/action-types.js
@@ -56,3 +56,5 @@ export const STORE_DATE = 'STORE_DATE';
 export const TOGGLE_DATE = 'TOGGLE_DATE';
 export const UPDATE_FHIR_MEDICATION_ORDER = 'UPDATE_FHIR_MEDICATION_ORDER';
 
+// Suggestions
+export const TAKE_SUGGESTION = 'TAKE_SUGGESTION';

--- a/src/actions/medication-select-actions.js
+++ b/src/actions/medication-select-actions.js
@@ -57,3 +57,10 @@ export function toggleDate(range) {
     range,
   };
 }
+
+export function takeSuggestion(suggestion) {
+  return {
+    type: types.TAKE_SUGGESTION,
+    suggestion,
+  };
+}

--- a/src/components/Card/card.jsx
+++ b/src/components/Card/card.jsx
@@ -39,7 +39,7 @@ export class Card extends Component {
         }
         this.props.takeSuggestion(suggestion);
       } else {
-        console.error('There was no label on this suggestions', suggestion);
+        console.error('There was no label on this suggestion', suggestion);
       }
     }
   }

--- a/src/components/Card/card.jsx
+++ b/src/components/Card/card.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import ReactMarkdown from 'react-markdown';
 import cx from 'classnames';
+import axios from 'axios';
 
 import TerraCard from 'terra-card';
 import Text from 'terra-text';
@@ -11,6 +12,7 @@ import Button from 'terra-button';
 import styles from './card.css';
 import retrieveLaunchContext from '../../retrieve-data-helpers/launch-context-retrieval';
 import { getServicesByHook, getCardsFromServices } from '../../reducers/helpers/services-filter';
+import { takeSuggestion } from '../../actions/medication-select-actions';
 
 const propTypes = {
   isDemoCard: PropTypes.bool,
@@ -23,6 +25,23 @@ export class Card extends Component {
     this.launchSource = this.launchSource.bind(this);
     this.renderSource = this.renderSource.bind(this);
     this.modifySmartLaunchUrls = this.modifySmartLaunchUrls.bind(this);
+  }
+
+  takeSuggestion(suggestion, url) {
+    if (!this.props.isDemoCard) {
+      if (suggestion.label) {
+        if (suggestion.uuid) {
+          axios({
+            method: 'POST',
+            url: `${url}/analytics/${suggestion.uuid}`,
+            data: {},
+          });
+        }
+        this.props.takeSuggestion(suggestion);
+      } else {
+        console.error('There was no label on this suggestions', suggestion);
+      }
+    }
   }
 
   /**
@@ -152,7 +171,7 @@ export class Card extends Component {
           suggestionsSection = card.suggestions.map((item, ind) => (
             <Button
               key={ind}
-              onClick={() => {}}
+              onClick={() => this.takeSuggestion(item, card.serviceUrl)}
               text={item.label}
               variant={Button.Opts.Variants.EMPHASIS}
             />
@@ -204,4 +223,10 @@ const mapStateToProps = store => ({
   patientId: store.patientState.currentPatient.id,
 });
 
-export default connect(mapStateToProps)(Card);
+const mapDispatchToProps = dispatch => ({
+  takeSuggestion: (suggestion) => {
+    dispatch(takeSuggestion(suggestion));
+  },
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(Card);

--- a/src/components/RxView/rx-view.jsx
+++ b/src/components/RxView/rx-view.jsx
@@ -51,7 +51,13 @@ export class RxView extends Component {
     this.toggleEnabledDate = this.toggleEnabledDate.bind(this);
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidMount() {
+    if (this.props.prescription) {
+      this.executeRequests();
+    }
+  }
+
+  async componentDidUpdate(prevProps) {
     if (!isEqual(prevProps.prescription, this.props.prescription) ||
         prevProps.patient !== this.props.patient ||
         prevProps.fhirServer !== this.props.fhirServer ||
@@ -59,7 +65,10 @@ export class RxView extends Component {
         !isEqual(prevProps.medicationInstructions, this.props.medicationInstructions) ||
         !isEqual(prevProps.prescriptionDates, this.props.prescriptionDates) ||
         prevProps.selectedConditionCode !== this.props.selectedConditionCode) {
-      this.props.updateFhirResource(this.props.fhirVersion, this.props.patient.id);
+      await this.props.updateFhirResource(this.props.fhirVersion, this.props.patient.id);
+      if (this.props.prescription) {
+        this.executeRequests();
+      }
     }
     return null;
   }
@@ -117,7 +126,12 @@ export class RxView extends Component {
     if (Object.keys(this.props.services).length) {
       // For each service, call service for request/response exchange
       forIn(this.props.services, (val, key) => {
-        callServices(key);
+        // TODO: Once default services are fixed to parse FHIR bundle, change this to FHIR bundle format
+        const context = [{
+          key: 'medications',
+          value: [this.props.medicationOrder],
+        }];
+        callServices(key, context);
       });
     }
   }

--- a/src/reducers/helpers/services-filter.js
+++ b/src/reducers/helpers/services-filter.js
@@ -28,7 +28,10 @@ export function getCardsFromServices(serviceUrls) {
       // Check if the service response for cards is valid and has at least one card
       if (response && Object.keys(response) && response.cards && response.cards.length) {
         response.cards.forEach((card) => {
-          totalCards.cards.push(card);
+          // Adding a serviceUrl property to each card to distinguish which card maps to which CDS Service (for suggestions analytics endpoint)
+          totalCards.cards.push(Object.assign({}, card, {
+            serviceUrl: url,
+          }));
         });
       }
     }

--- a/src/reducers/medication-reducers.js
+++ b/src/reducers/medication-reducers.js
@@ -349,6 +349,11 @@ const medicationReducers = (state = initialState, action) => {
                       },
                     });
                   }
+                  console.warn('Suggested resource does not have text and/or coding code in medicationCodeableConcept property', newMedication);
+                } else if (!actions[i].resource) {
+                  console.warn('Could not find an accompanying resource for the suggestion', actions[i]);
+                } else if (!actions[i].resource.medicationCodeableConcept) {
+                  console.warn('Suggested resource does not have a medicationCodeableConcept', actions[i].resource);
                 }
               } else if (actions[i].type === 'delete') {
                 return Object.assign({}, state, {

--- a/src/reducers/service-exchange-reducers.js
+++ b/src/reducers/service-exchange-reducers.js
@@ -54,6 +54,13 @@ const serviceExchangeReducers = (state = initialState, action) => {
         }
         break;
       }
+      // Clear the selected service to display request/response for when the view changes
+      case types.SET_HOOK: {
+        return Object.assign({}, state, {
+          selectedService: '',
+        });
+      }
+
       default: {
         return state;
       }

--- a/src/retrieve-data-helpers/service-exchange.js
+++ b/src/retrieve-data-helpers/service-exchange.js
@@ -100,8 +100,13 @@ function callServices(url, context) {
   const user = state.patientState.defaultUserId;
 
   const patient = state.patientState.currentPatient.id;
-  const activityContext = context || {};
+  const activityContext = {};
   activityContext.patientId = patient;
+  if (context && context.length) {
+    context.forEach((contextKey) => {
+      activityContext[contextKey.key] = contextKey.value;
+    });
+  }
 
   const hookInstance = uuidv4();
   const request = {
@@ -148,7 +153,10 @@ function callServices(url, context) {
     method: 'post',
     url,
     data: request,
-    headers: { Accept: 'application/json' },
+    headers: {
+      Accept: 'application/json',
+      Authorization: `Bearer ${generateJWT(url)}`,
+    },
   }).then((result) => {
     if (result.data && Object.keys(result.data).length) {
       store.dispatch(storeExchange(url, request, result.data, result.status));

--- a/tests/actions/medication-select-actions.test.js
+++ b/tests/actions/medication-select-actions.test.js
@@ -82,4 +82,14 @@ describe('Medication Select Actions', () => {
 
     expect(actions.toggleDate(range)).toEqual(expectedAction);
   });
+
+  it('creates action to take a suggestion', () => {
+    const suggestion = { foo: 'foo' };
+    const expectedAction = {
+      type: types.TAKE_SUGGESTION,
+      suggestion,
+    };
+
+    expect(actions.takeSuggestion(suggestion)).toEqual(expectedAction);
+  });
 });

--- a/tests/components/RxView/intl-context-setup.js
+++ b/tests/components/RxView/intl-context-setup.js
@@ -4,8 +4,8 @@ const locale = 'en-US';
 const intlProvider = new IntlProvider({ locale }, {});
 const { intl } = intlProvider.getChildContext();
 
-const shallowContext = { context: { intl } };
-const mountContext = { context: { intl }, childContextTypes: { intl: intlShape } };
+const shallowContext = { context: { intl }, lifecycleExperimental: true };
+const mountContext = { context: { intl }, childContextTypes: { intl: intlShape }, lifecycleExperimental: true };
 
 const intlContexts = { shallowContext, mountContext };
 

--- a/tests/components/RxView/rx-view.test.js
+++ b/tests/components/RxView/rx-view.test.js
@@ -22,7 +22,7 @@ describe('RxView component', () => {
   let prescription;
 
   let chooseCondition, onMedicationChangeInput, chooseMedication,
-  updateDosageInstructions, updateDate, toggleEnabledDate;
+  updateDosageInstructions, updateDate, toggleEnabledDate, updateFhirResource;
 
   function setup(patient, medListPhase, prescription) {
     jest.setMock('../../../src/retrieve-data-helpers/service-exchange', mockSpy);
@@ -49,7 +49,7 @@ describe('RxView component', () => {
         services={services} hook={'medication-prescribe'} medListPhase={medListPhase} 
         medications={medications} prescription={prescription} onMedicationChangeInput={onMedicationChangeInput} 
         chooseMedication={chooseMedication} chooseCondition={chooseCondition} updateDosageInstructions={updateDosageInstructions} 
-        updateDate={updateDate} toggleEnabledDate={toggleEnabledDate} />;
+        updateDate={updateDate} toggleEnabledDate={toggleEnabledDate} updateFhirResource={updateFhirResource} />;
     renderedComponent = shallow(component, intlContexts.shallowContext);
   }
 
@@ -92,6 +92,7 @@ describe('RxView component', () => {
     updateDosageInstructions = jest.fn(); 
     updateDate = jest.fn();
     toggleEnabledDate = jest.fn();
+    updateFhirResource = jest.fn(() => 1);
   });
 
   afterEach(() => {
@@ -150,5 +151,18 @@ describe('RxView component', () => {
     expect(toggleEnabledDate).toHaveBeenCalled();
     renderedComponent.find('.dosage-timing').find('DatePicker').at(1).simulate('change', { target: { value: '2018-04-14' } });
     expect(updateDate).toHaveBeenCalled();
+  });
+
+  it('updates the FHIR resource and calls CDS Services if a prescription is selected', async (done) => {
+    setup(patient, medListPhase, medications, prescription);
+    prescription = {
+      name: 'another prescribable med',
+      id: '456',
+    };
+    let newComponent = await renderedComponent.setProps({ prescription: prescription });
+    Promise.resolve(newComponent).then(() => {
+      expect(mockSpy).toHaveBeenCalledTimes(2);
+      done();
+    });
   });
 });

--- a/tests/reducers/helpers/services-filter.test.js
+++ b/tests/reducers/helpers/services-filter.test.js
@@ -111,8 +111,12 @@ describe('Services Filters', () => {
     it('gathers all cards into one cards array from passed in services', () => {
       expect(getCardsFromServices(arrayOfServices)).toEqual({
         cards: [
-          testStore.serviceExchangeState.exchanges[completeServiceExchange].response.cards[0],
-          testStore.serviceExchangeState.exchanges[exampleServiceExchange].response.cards[0],
+          Object.assign({}, testStore.serviceExchangeState.exchanges[completeServiceExchange].response.cards[0], {
+            serviceUrl: completeServiceExchange,
+          }),
+          Object.assign({}, testStore.serviceExchangeState.exchanges[exampleServiceExchange].response.cards[0], {
+            serviceUrl: exampleServiceExchange,
+          }),
         ]
       })
     });

--- a/tests/reducers/medication-reducers.test.js
+++ b/tests/reducers/medication-reducers.test.js
@@ -276,6 +276,84 @@ describe('Medication Reducers', () => {
     });
   });
 
+  describe('TAKE_SUGGESTION', () => {
+    it('should handle the TAKE_SUGGESTION action for a "create" suggestion', () => {
+      state.fhirResource = {
+        medicationCodeableConcept: {
+          foo: 'foo',
+        },
+      };
+      let createSuggestion = {
+        actions: [
+          {
+            type: 'create',
+            description: 'test',
+            resource: {
+              medicationCodeableConcept: {
+                text: 'new drug',
+                coding: [
+                  {
+                    code: '999',
+                  },
+                ],
+              },
+            },
+          },
+        ],
+      };
+      const action = {
+        type: types.TAKE_SUGGESTION,
+        suggestion: createSuggestion,
+      };
+
+      const newState = Object.assign({}, state, {
+        ...state,
+        medListPhase: 'done',
+        decisions: {
+          ...state.decisions,
+          prescribable: {
+            name: 'new drug',
+            id: '999',
+          },
+        },
+      });
+      expect(reducer(state, action)).toEqual(newState);
+    });
+
+    it('should handle the TAKE_SUGGESTION action for a "delete" suggestion', () => {
+      const suggestion = {
+        actions: [
+          {
+            type: 'delete',
+            description: 'test',
+          },
+        ],
+      };
+      const action = {
+        type: types.TAKE_SUGGESTION,
+        suggestion,
+      };
+
+      const newState = Object.assign({}, state, {
+        ...state,
+        medListPhase: 'ingredient',
+        options: {
+          ingredient: [],
+          components: [],
+          prescribable: [],
+        },
+        decisions: {
+          ingredient: null,
+          components: null,
+          prescribable: null,
+        },
+        fhirResource: null,
+      });
+
+      expect(reducer(state, action)).toEqual(newState);
+    });
+  });
+
   describe('Pass-through Actions', () => {
     it('should return state if an action should pass through this reducer without change to state', () => {
       const action = { type: 'SOME_OTHER_ACTION' };

--- a/tests/reducers/service-exchange-reducers.test.js
+++ b/tests/reducers/service-exchange-reducers.test.js
@@ -135,6 +135,15 @@ describe('Services Exchange Reducers', () => {
     });
   });
 
+  describe('SET_HOOK', () => {
+    it('should clear the selected service on a hook change', () => {
+      const action = {
+        type: types.SET_HOOK,
+      };
+      expect(reducer(state, action)).toEqual(Object.assign({}, state, { selectedService: '' }));
+    });
+  });
+
   describe('Pass-through Actions', () => {
     it('should return state if an action should pass through this reducer without change to state', () => {
       const action = { type: 'SOME_OTHER_ACTION' };

--- a/tests/retrieve-data-helpers/service-exchange.test.js
+++ b/tests/retrieve-data-helpers/service-exchange.test.js
@@ -21,6 +21,7 @@ describe('Service Exchange', () => {
   let mockServiceWithoutPrefetch;
   let mockHookInstance;
   let mockRequest;
+  let mockRequestWithContext;
 
   let noDataMessage = 'No response returned. Check developer tools for more details.';
   let failedServiceCallMessage = 'Could not get a response from the CDS Service. See developer tools for more details';
@@ -58,6 +59,14 @@ describe('Service Exchange', () => {
       patient: mockPatient,
       context: { patientId: mockPatient }
     };
+    mockRequestWithContext = Object.assign({}, mockRequest, {
+      context: {
+        ...mockRequest.context,
+        medications: [{
+          foo: 'foo',
+        }],
+      },
+    });
 
     defaultStore = {
       hookState: { currentHook: 'patient-view' },
@@ -186,6 +195,20 @@ describe('Service Exchange', () => {
       mockAxios.onPost(mockServiceWithoutPrefetch).reply(500);
       return callServices(mockServiceWithoutPrefetch).then(() => {
         expect(spy).toHaveBeenCalledWith(mockServiceWithoutPrefetch, mockRequest, failedServiceCallMessage);
+      });
+    });
+
+    it('resolves with context passed in for the context parameter', () => {
+      const serviceResultStatus = 200;
+      mockAxios.onPost(mockServiceWithoutPrefetch).reply(serviceResultStatus, mockServiceResult);
+      const context = [
+        {
+          key: 'medications',
+          value: [{ foo: 'foo' }],
+        },
+      ];
+      return callServices(mockServiceWithoutPrefetch, context).then(() => {
+        expect(spy).toHaveBeenCalledWith(mockServiceWithoutPrefetch, mockRequestWithContext, mockServiceResult, serviceResultStatus)
       });
     });
   });


### PR DESCRIPTION
After choosing a medication and any subsequent changes on the RxView have been made, the Sandbox should create the request for triggering services configured to listen for the `medication-prescribe` hook. This means once a medication has been chosen on RxView, any changes to the start/end date, condition chosen, instructions, etc. will trigger the services configured for `medication-prescribe`. Accordingly, the cards should appear below the Rx form. Additionally, if any suggestion buttons are clicked on any card, the UI should update to accommodate the suggestion, and the analytics endpoint will be hit if a UUID is supplied in the service response for a suggestion.

@kpshek 