### PR TITLE
Perist configured FHIR server, patient ID, view, and CDS Services on localStorage to rehydrate on page refresh. Add support for serviceDiscoveryURL param in access tokens on SMART launch

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,6 +7,7 @@ module.exports = {
     "window": true,
     "FHIR": true,
     "document": true,
+    "localStorage": true,
   },
   "rules": {
     "no-console": 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -513,6 +513,17 @@
         "trim-right": "1.0.1"
       }
     },
+    "babel-helper-builder-binary-assignment-operator-visitor": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+      "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
+      "dev": true,
+      "requires": {
+        "babel-helper-explode-assignable-expression": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
     "babel-helper-builder-react-jsx": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
@@ -546,6 +557,17 @@
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
         "lodash": "4.17.5"
+      }
+    },
+    "babel-helper-explode-assignable-expression": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+      "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
       }
     },
     "babel-helper-function-name": {
@@ -701,6 +723,12 @@
       "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
       "dev": true
     },
+    "babel-plugin-syntax-exponentiation-operator": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
+      "dev": true
+    },
     "babel-plugin-syntax-flow": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
@@ -717,6 +745,12 @@
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
+      "dev": true
+    },
+    "babel-plugin-syntax-trailing-function-commas": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
       "dev": true
     },
     "babel-plugin-transform-async-to-generator": {
@@ -964,6 +998,17 @@
         "regexpu-core": "2.0.0"
       }
     },
+    "babel-plugin-transform-exponentiation-operator": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+      "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
+      "dev": true,
+      "requires": {
+        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
+        "babel-runtime": "6.26.0"
+      }
+    },
     "babel-plugin-transform-flow-strip-types": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
@@ -1059,6 +1104,56 @@
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
           "dev": true
+        }
+      }
+    },
+    "babel-preset-env": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
+      "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+        "babel-plugin-transform-async-to-generator": "6.24.1",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-exponentiation-operator": "6.24.1",
+        "babel-plugin-transform-regenerator": "6.26.0",
+        "browserslist": "2.11.3",
+        "invariant": "2.2.2",
+        "semver": "5.5.0"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "2.11.3",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
+          "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "1.0.30000810",
+            "electron-to-chromium": "1.3.34"
+          }
         }
       }
     },

--- a/src/actions/cds-services-actions.js
+++ b/src/actions/cds-services-actions.js
@@ -17,12 +17,14 @@ export function signalRetrievingServices(testUrl) {
 /**
  * Signals successful retrieval of CDS Services. Used to update state with CDS Services found (definitions).
  * @param services - CDS Services found at discovery endpoint
+ * @param discoveryUrl - Discovery endpoint URL
  * @returns {{type, services: *}} - Action to dispatch
  */
-export function signalSuccessServicesRetrieval(services) {
+export function signalSuccessServicesRetrieval(services, discoveryUrl) {
   return {
     type: types.DISCOVER_CDS_SERVICES_SUCCESS,
     services,
+    discoveryUrl,
   };
 }
 

--- a/src/components/Card/card.css
+++ b/src/components/Card/card.css
@@ -7,6 +7,12 @@
   border-left-width: 3px;
 }
 
+.decision-card img {
+  display: block;
+  width: 100px;
+  margin: 0 0 5px;
+}
+
 .card-icon {
   display: block;
   width: 100px;

--- a/src/components/Card/card.jsx
+++ b/src/components/Card/card.jsx
@@ -163,7 +163,7 @@ export class Card extends Component {
         const sourceSection = card.source && Object.keys(card.source).length ? this.renderSource(card.source) : '';
 
         // -- Detail --
-        const detailSection = card.detail ? <ReactMarkdown source={card.detail} /> : '';
+        const detailSection = card.detail ? <ReactMarkdown escapeHtml={false} softBreak="br" source={card.detail} /> : '';
 
         // -- Suggestions --
         let suggestionsSection;

--- a/src/components/Header/header.jsx
+++ b/src/components/Header/header.jsx
@@ -113,6 +113,16 @@ export class Header extends Component {
 
   render() {
     const logo = <div><span><img src={cdsHooksLogo} alt="" height="30" width="30" /></span><b className={styles['logo-title']}>CDS Hooks Sandbox</b></div>;
+    const menuItems = [
+      <Menu.Item text="Add CDS Services" key="add-services" onClick={this.openAddServices} />,
+      <Menu.Item text="Reset Default Services" key="reset-services" onClick={this.resetServices} />,
+      <Menu.Item text="Configure CDS Services" key="configure-services" onClick={this.openConfigureServices} />,
+      <Menu.Divider key="Divider1" />,
+      <Menu.Item text="Change Patient" key="change-patient" onClick={this.openChangePatient} />,
+    ];
+    if (!this.props.isSecuredSandbox) {
+      menuItems.push(<Menu.Item text="Change FHIR Server" key="change-fhir-server" onClick={this.openChangeFhirServer} />);
+    }
     const gearMenu = (
       <Menu
         isOpen={this.state.settingsOpen}
@@ -120,12 +130,7 @@ export class Header extends Component {
         targetRef={this.getSettingsNode}
         isArrowDisplayed
       >
-        <Menu.Item text="Add CDS Services" key="add-services" onClick={this.openAddServices} />
-        <Menu.Item text="Reset Default Services" key="reset-services" onClick={this.resetServices} />
-        <Menu.Item text="Configure CDS Services" key="configure-services" onClick={this.openConfigureServices} />
-        <Menu.Divider key="Divider1" />
-        <Menu.Item text="Change Patient" key="change-patient" onClick={this.openChangePatient} />
-        <Menu.Item text="Change FHIR Server" key="change-fhir-server" onClick={this.openChangeFhirServer} />
+        {menuItems}
       </Menu>);
 
     const navigation = (
@@ -189,6 +194,7 @@ const mapStateToProps = store => ({
   hook: store.hookState.currentHook,
   patientId: store.patientState.currentPatient.id,
   isCardDemoView: store.cardDemoState.isCardDemoView,
+  isSecuredSandbox: store.fhirServerState.accessToken,
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/middleware/persist-data.js
+++ b/src/middleware/persist-data.js
@@ -1,0 +1,24 @@
+/* eslint no-unused-vars: 0 */
+
+export const persistFhirServer = store => next => (action) => {
+  if (action.type === 'GET_FHIR_SERVER_SUCCESS') {
+    if (!store.getState().fhirServerState.accessToken) {
+      localStorage.setItem('PERSISTED_fhirServer', action.baseUrl);
+    }
+  }
+  return next(action);
+};
+
+export const persistPatient = store => next => (action) => {
+  if (action.type === 'GET_PATIENT_SUCCESS') {
+    localStorage.setItem('PERSISTED_patientId', action.patient.id);
+  }
+  return next(action);
+};
+
+export const persistHook = store => next => (action) => {
+  if (action.type === 'SET_HOOK') {
+    localStorage.setItem('PERSISTED_hook', action.hook);
+  }
+  return next(action);
+};

--- a/src/reducers/hook-reducers.js
+++ b/src/reducers/hook-reducers.js
@@ -21,7 +21,7 @@ const hookReducers = (state = initialState, action) => {
 
       // Set hook for the application
       case types.SET_HOOK: {
-        return Object.assign({}, state, { currentHook: action.hook });
+        return Object.assign({}, state, { currentHook: action.hook || state.currentHook });
       }
       default:
         return state;

--- a/src/reducers/service-exchange-reducers.js
+++ b/src/reducers/service-exchange-reducers.js
@@ -17,7 +17,7 @@ const serviceExchangeReducers = (state = initialState, action) => {
           service.responseStatus = action.responseStatus;
           const exchanges = Object.assign({}, state.exchanges);
           exchanges[action.url] = service;
-          return Object.assign({}, state, { selectedService: action.url, exchanges });
+          return Object.assign({}, state, { selectedService: state.selectedService || action.url, exchanges });
         }
         break;
       }

--- a/src/retrieve-data-helpers/discovery-services-retrieval.js
+++ b/src/retrieve-data-helpers/discovery-services-retrieval.js
@@ -28,7 +28,7 @@ function retrieveDiscoveryServices(testUrl) {
       },
     }).then((result) => {
       if (result.data && result.data.services && result.data.services.length) {
-        store.dispatch(signalSuccessServicesRetrieval(result.data.services));
+        store.dispatch(signalSuccessServicesRetrieval(result.data.services, discoveryUrl));
         return resolve();
       }
       return reject();

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -4,14 +4,20 @@ import { applyMiddleware, createStore } from 'redux';
 import { createLogger } from 'redux-logger';
 import immutableStateWatcher from 'redux-immutable-state-invariant';
 import reducers from '../reducers/index';
+import { persistFhirServer, persistPatient, persistHook } from '../middleware/persist-data';
 
 const logger = createLogger({
   collapsed: true,
 });
 
-const middleware = process.env.NODE_ENV !== 'production' ?
+const loggerMiddleware = process.env.NODE_ENV !== 'production' ?
   [immutableStateWatcher(), logger] : [];
 
 // Create the Redux store, and apply logging middleware
-const store = createStore(reducers, applyMiddleware(...middleware));
+const store = createStore(reducers, applyMiddleware(
+  persistFhirServer,
+  persistPatient,
+  persistHook,
+  ...loggerMiddleware,
+));
 export default store;

--- a/tests/actions/cds-services-actions.test.js
+++ b/tests/actions/cds-services-actions.test.js
@@ -14,12 +14,14 @@ describe('CDS Services Actions', () => {
 
   it('creates action to signal a successful connection to CDS Services', () => {
     const services = { hook: 'patient-view', id: 'example-service' };
+    const discoveryUrl = 'http://discovery.com/cds-services';
     const expectedAction = {
       type: types.DISCOVER_CDS_SERVICES_SUCCESS,
       services,
+      discoveryUrl,
     };
 
-    expect(actions.signalSuccessServicesRetrieval(services)).toEqual(expectedAction);
+    expect(actions.signalSuccessServicesRetrieval(services, discoveryUrl)).toEqual(expectedAction);
   });
 
   it('creates action to signal a failed connection to CDS Services', () => {

--- a/tests/components/Header/header.test.js
+++ b/tests/components/Header/header.test.js
@@ -25,7 +25,10 @@ describe('Header component', () => {
       patientState: { currentPatient: { id: 'patient-123' } },
       cardDemoState: {
         isCardDemoView: false,
-      }, 
+      },
+      fhirServerState: {
+        accessToken: null,
+      },
     };
     mockStore = mockStoreWrapper(storeState);
     let component = <ConnectedView store={mockStore} />;
@@ -60,6 +63,29 @@ describe('Header component', () => {
     expect(shallowedComponent.state('settingsOpen')).toBeTruthy();
     shallowedComponent.find('Menu').childAt(0).simulate('click');
     expect(shallowedComponent.state('settingsOpen')).toBeFalsy();
+  });
+
+  it('should display option to change FHIR server if no access token is configured for the application', () => {
+    shallowedComponent.childAt(0).dive().find('.icon').first().simulate('click');
+    expect(shallowedComponent.find('Menu').children().length).toEqual(6);
+    expect(shallowedComponent.find('Menu').childAt(5).key()).toEqual('change-fhir-server');
+  });
+
+  it('should not display option to change FHIR server if an access token is configured for the application', () => {
+    storeState = Object.assign({}, storeState, {
+      ...storeState,
+      fhirServerState: {
+        accessToken: {
+          serviceDiscoveryUrl: 'http://pre-configured-service.com/cds-services',
+        },
+      },
+    });
+    mockStore = mockStoreWrapper(storeState);
+    let component = <ConnectedView store={mockStore} />;
+    shallowedComponent = shallow(component).find(Header).shallow();
+
+    shallowedComponent.childAt(0).dive().find('.icon').first().simulate('click');
+    expect(shallowedComponent.find('Menu').children().length).toEqual(5);
   });
 
   describe('Change Patient', () => {

--- a/tests/jest-setup.js
+++ b/tests/jest-setup.js
@@ -1,5 +1,6 @@
 import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import LocalStorageMock from './local-storage-mock';
 
 console.warn = jest.fn();
 
@@ -7,3 +8,5 @@ Enzyme.configure({ adapter: new Adapter() });
 
 const htmlTag = document.getElementsByTagName('html')[0];
 htmlTag.setAttribute('dir', 'ltr');
+
+global.localStorage = new LocalStorageMock;

--- a/tests/local-storage-mock.js
+++ b/tests/local-storage-mock.js
@@ -1,0 +1,23 @@
+class LocalStorageMock {
+  constructor() {
+    this.store = {};
+  }
+
+  clear() {
+    this.store = {};
+  }
+
+  getItem(key) {
+    return this.store[key] || null;
+  }
+
+  setItem(key, value) {
+    this.store[key] = (value && value.toString()) || null;
+  }
+
+  removeItem(key) {
+    delete this.store[key];
+  }
+};
+
+export default LocalStorageMock;

--- a/tests/middleware/persist-data.test.js
+++ b/tests/middleware/persist-data.test.js
@@ -1,0 +1,140 @@
+import * as persist from '../../src/middleware/persist-data';
+
+describe('Persist Data Middleware', () => {
+  let createMock;
+
+  const setup = (persistedMethod, mockStore) => {
+    createMock = () => {
+      const store = {
+        getState: jest.fn(() => mockStore),
+      };
+      const next = jest.fn();
+      const invoke = (action) => persistedMethod(store)(next)(action);
+
+      return { store, next, invoke }
+    };
+  }
+
+  afterEach(() => {
+    localStorage.clear();
+  })
+
+  describe('Persist FHIR Server', () => {
+    it('persists a FHIR server if the action is a FHIR server success action', () => {
+      const store = {
+        fhirServerState: {
+          accessToken: null,
+        },
+      };
+      setup(persist.persistFhirServer, store);
+      expect(localStorage.getItem('PERSISTED_fhirServer')).toEqual(null);
+      const { next, invoke } = createMock();
+      const action = {
+        type: 'GET_FHIR_SERVER_SUCCESS',
+        baseUrl: 'http://example.com',
+      };
+
+      invoke(action);
+      expect(localStorage.getItem('PERSISTED_fhirServer')).toEqual('http://example.com');
+      expect(next).toHaveBeenCalledWith(action);
+    });
+
+    it('does not persist FHIR server if there is an access token stored on application state', () => {
+      const store = {
+        fhirServerState: {
+          accessToken: '123',
+        },
+      };
+      setup(persist.persistFhirServer, store);
+      expect(localStorage.getItem('PERSISTED_fhirServer')).toEqual(null);
+      const { next, invoke } = createMock();
+      const action = {
+        type: 'GET_FHIR_SERVER_SUCCESS',
+        baseUrl: 'http://example.com',
+      };
+
+      invoke(action);
+      expect(localStorage.getItem('PERSISTED_fhirServer')).toEqual(null);
+      expect(next).toHaveBeenCalledWith(action);
+    });
+
+    it('ignores setting localStorage for actions whose type is not GET_FHIR_SERVER_SUCCESS', () => {
+      setup(persist.persistFhirServer);
+      const baseUrl = 'http://example.com';
+      localStorage.setItem('PERSISTED_fhirServer', baseUrl);
+      const { next, invoke } = createMock();
+      const action = {
+        type: 'GET_FHIR_SERVER_FAILURE',
+        baseUrl: 'http://other-example.com',
+      };
+
+      invoke(action);
+      expect(localStorage.getItem('PERSISTED_fhirServer')).not.toEqual('http://other-example.com');
+      expect(next).toHaveBeenCalledWith(action);
+    });
+  });
+
+  describe('Persist Patient', () => {
+    beforeEach(() => { setup(persist.persistPatient); });
+    it('persists a patient ID if the action is a patient success action', () => {
+      expect(localStorage.getItem('PERSISTED_patientId')).toEqual(null);
+      const { next, invoke } = createMock();
+      const action = {
+        type: 'GET_PATIENT_SUCCESS',
+        patient: {
+          id: '123',
+        },
+      };
+
+      invoke(action);
+      expect(localStorage.getItem('PERSISTED_patientId')).toEqual('123');
+      expect(next).toHaveBeenCalledWith(action);
+    });
+
+    it('ignores actions whose type is not GET_PATIENT_SUCCESS', () => {
+      const patientId = '123';
+      localStorage.setItem('PERSISTED_patientId', patientId);
+      const { next, invoke } = createMock();
+      const action = {
+        type: 'GET_PATIENT_FAILURE',
+        patient: {
+          id: '098',
+        },
+      };
+
+      invoke(action);
+      expect(localStorage.getItem('PERSISTED_patientId')).not.toEqual('098');
+      expect(next).toHaveBeenCalledWith(action);
+    });
+  });
+
+  describe('Persist Hook', () => {
+    beforeEach(() => { setup(persist.persistHook); })
+    it('persists a hook name if the action is a set hook action', () => {
+      expect(localStorage.getItem('PERSISTED_hook')).toEqual(null);
+      const { next, invoke } = createMock();
+      const action = {
+        type: 'SET_HOOK',
+        hook: 'medication-prescribe',
+      };
+
+      invoke(action);
+      expect(localStorage.getItem('PERSISTED_hook')).toEqual('medication-prescribe');
+      expect(next).toHaveBeenCalledWith(action);
+    });
+
+    it('ignores setting localStorage for actions whose type is not SET_HOOK', () => {
+      const hook = 'medication-prescribe';
+      localStorage.setItem('PERSISTED_hook', hook);
+      const { next, invoke } = createMock();
+      const action = {
+        type: 'SOME_OTHER_ACTION',
+        hook: 'some-other-hook',
+      };
+
+      invoke(action);
+      expect(localStorage.getItem('PERSISTED_hook')).not.toEqual('some-other-hook');
+      expect(next).toHaveBeenCalledWith(action);
+    });
+  });
+});

--- a/tests/reducers/cds-services-reducers.test.js
+++ b/tests/reducers/cds-services-reducers.test.js
@@ -3,17 +3,20 @@ import * as types from '../../src/actions/action-types';
 
 describe('CDS Services Reducer', () => {
   let state = {};
+  let persistedService = 'http://stored-service.com/cds-services';
 
   beforeEach(() => {
+    localStorage.setItem('PERSISTED_cdsServices', JSON.stringify([persistedService]));
     state = {
       configuredServices: {},
+      configuredServiceUrls: [persistedService],
       defaultUrl: 'https://fhir-org-cds-services.appspot.com/cds-services',
       testServicesUrl: null,
     };
   });
 
   it('should return the initial state without action', () => {
-    expect(reducer(undefined, {})).toEqual(state);
+    expect(reducer(undefined, {})).toEqual(Object.assign({}, state, { configuredServiceUrls: [] }));
   });
 
   describe('DISCOVER_CDS_SERVICES', () => {
@@ -56,6 +59,7 @@ describe('CDS Services Reducer', () => {
       const action = {
         type: types.DISCOVER_CDS_SERVICES_SUCCESS,
         services: [service],
+        discoveryUrl: exampleUrl,
       };
       expect(reducer(state, action)).toEqual(state);
     });
@@ -71,14 +75,17 @@ describe('CDS Services Reducer', () => {
       const action = {
         type: types.DISCOVER_CDS_SERVICES_SUCCESS,
         services: [service],
+        discoveryUrl: exampleUrl,
       };
       const configuredServices = {};
       configuredServices[`${service.url}`] = service;
       const newState = Object.assign({}, state, {
         configuredServices: configuredServices,
+        configuredServiceUrls: [persistedService, exampleUrl],
         testServicesUrl: null,
       });
       expect(reducer(state, action)).toEqual(newState);
+      expect(localStorage.getItem('PERSISTED_cdsServices')).toEqual(JSON.stringify([persistedService, exampleUrl]));
     });
   });
 
@@ -87,6 +94,7 @@ describe('CDS Services Reducer', () => {
       state.configuredServices['http://example.com'] = { enabled: true };
       const stateCopy = JSON.parse(JSON.stringify(state));
       stateCopy.configuredServices = {};
+      stateCopy.configuredServiceUrls = [];
       stateCopy.testServicesUrl = '';
       const action = {
         type: types.RESET_SERVICES,

--- a/tests/reducers/hook-reducers.test.js
+++ b/tests/reducers/hook-reducers.test.js
@@ -49,7 +49,16 @@ describe('Hook Reducer', () => {
 
       const newState = Object.assign({}, state, { currentHook: action.hook });
       expect(reducer(state, action)).toEqual(newState);
-    })
+    });
+
+    it('should keep the current hook if the incoming hook is not valid', () => {
+      const action = {
+        type: types.SET_HOOK,
+        hook: '',
+      };
+
+      expect(reducer(state, action)).toEqual(state);
+    });
   });
 
   describe('Pass-through Actions', () => {

--- a/tests/reducers/service-exchange-reducers.test.js
+++ b/tests/reducers/service-exchange-reducers.test.js
@@ -43,6 +43,24 @@ describe('Services Exchange Reducers', () => {
       });
       expect(reducer(state, action)).toEqual(newState);
     });
+
+    it('should store the request/response of an exchange but keep the selectedService if already set', () => {
+      state.selectedService = url;
+      const extraUrl = 'http://some-other-url.com/cds-services/1';
+      const action = Object.assign({
+        type: types.STORE_SERVICE_EXCHANGE,
+        url: extraUrl,
+      }, storedExchange);
+
+
+      const newState = Object.assign({}, state, {
+        selectedService: url,
+        exchanges: {
+          [extraUrl]: storedExchange
+        }
+      });
+      expect(reducer(state, action)).toEqual(newState);
+    });
   });
 
   describe('SELECT_SERVICE_CONTEXT', () => {

--- a/tests/retrieve-data-helpers/discovery-services-retrieval.test.js
+++ b/tests/retrieve-data-helpers/discovery-services-retrieval.test.js
@@ -60,7 +60,7 @@ describe('Discovery Services Retrieval', () => {
         });
 
       return retrieveServices().then(() => {
-        expect(spy).toHaveBeenCalledWith([service]);
+        expect(spy).toHaveBeenCalledWith([service], defaultServicesUrl);
         spy.mockReset();
         spy.mockRestore();
       });

--- a/tests/retrieve-data-helpers/smart-launch.test.js
+++ b/tests/retrieve-data-helpers/smart-launch.test.js
@@ -10,6 +10,7 @@ describe('SMART Launch', () => {
   let expectedMetadata;
 
   let smartLaunchPromise; // function to test
+  let retrieveDiscoveryServices;
 
   console.log = jest.fn();
   console.error = jest.fn();
@@ -25,9 +26,11 @@ describe('SMART Launch', () => {
       resourceType: 'Conformance',
     };
 
+    retrieveDiscoveryServices = jest.fn();
     const mockStoreWrapper = configureStore([]);
     mockStore = mockStoreWrapper(defaultStore);
     jest.setMock('../../src/store/store', mockStore);
+    jest.setMock('../../src/retrieve-data-helpers/discovery-services-retrieval', retrieveDiscoveryServices);
     smartLaunchPromise = require('../../src/retrieve-data-helpers/smart-launch').default;
     actions = require('../../src/actions/smart-auth-actions');
   });
@@ -50,9 +53,12 @@ describe('SMART Launch', () => {
       global.FHIR = FHIR;
     });
     describe('and the response contains a token response', () => {
+      let tokenDiscoveryUrl;
       beforeEach(() => {
+        tokenDiscoveryUrl = 'http://token-discovery-url.com/cds-services';
         smartResponse.tokenResponse = {
-          foo: 'foo'
+          foo: 'foo',
+          serviceDiscoveryURL: tokenDiscoveryUrl,
         };
       });
 
@@ -90,6 +96,22 @@ describe('SMART Launch', () => {
             }];
           return smartLaunchPromise().then(() => {
             expect(actions).toEqual(expectedActions);
+          });
+        });
+
+        it('calls to retrieve discovery services if there is a serviceDiscoveryURL parameter in the access token', () => {
+          const actions = mockStore.getActions();
+          const expectedActions = [{
+              type: 'SMART_AUTH_SUCCESS',
+              authResponse: smartResponse
+            }, {
+              type: 'GET_FHIR_SERVER_SUCCESS',
+              baseUrl: securedFhirServer,
+              metadata: expectedMetadata
+            }
+          ];
+          return smartLaunchPromise().then(() => {
+            expect(retrieveDiscoveryServices).toHaveBeenCalledWith(tokenDiscoveryUrl);
           });
         });
       });


### PR DESCRIPTION
In order to make configuration in the Sandbox easier on the user, we can persist any configured FHIR server, patient ID, and added CDS Services onto the window's `localStorage` object. This means that upon a refresh, the cached values above will be configured automatically onto the Sandbox, so that the user does not have to re-enter their FHIR server, patient ID, or CDS Services. User's can clear their cache if they want to remove these values from `localStorage`, or the `Reset Default Services` option on the settings in the header can remove configured CDS Services from cache. Additional properties can be cached later on as needed.

Also, we should keep the existing functionality to automatically add CDS Services to the Sandbox from the `serviceDiscoveryURL` property on a token response (if the Sandbox is launched securely). This is a launch context key that contains a value string which is the discovery endpoint of a CDS Service. For more details, [see this merged PR](https://github.com/cds-hooks/sandbox/pull/108).

@kpshek 