### PR TITLE
Update readme with a more local development guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The CDS Hooks Sandbox (coined here as "Sandbox") is a tool that allows users to simulate the workflow of the [CDS Hooks](http://cds-hooks.org/) standard. It acts as a sort of "mock"-EHR that can be used as a demonstration tool for showing how CDS Hooks would work with an EHR system, as well as a testing tool to try out different CDS Services to ensure compatibility with the spec.
 
-Try out the live tool at [http://sandbox.cds-hooks.org](http://sandbox.cds-hooks.org)!
+Try out the live tool at [https://cds-hooks.github.io/sandbox-2.0](https://cds-hooks.github.io/sandbox-2.0)!
 
 
 ## How it Works
@@ -14,109 +14,87 @@ The Sandbox can act as a demo tool to simulate CDS Hooks and visualize the workf
 The Sandbox supports the following CDS Hooks Workflows:
 
 - `patient-view`: On initial load, the Sandbox displays what looks like the opening of a patient's chart. A default CDS Service displays a card pertaining to the `patient-view` hook invoked on this view. On the toolbar in the header, the Patient View tab should be highlighted to indicate this default view. When navigated to this view, the Sandbox will invoke configured CDS Services listening on the `patient-view` hook.
-- `medication-prescribe`: Invoked by the Rx View tab on the header, the Sandbox displays an EHR-like view of a form a care provider would use to author a medication for a specific condition. With the patient in context, you can drill down into the specific (if any) conditions the patient has. Additionally, you can choose from an extensive list of medications to prescribe, and adjust dosage instructions accordingly. Any action taken on this view will invoke the configured CDS Services on this tool listening on the `medication-prescribe` hook.
-   
+- `medication-prescribe`: Invoked by the Rx View tab on the header, the Sandbox displays an EHR-like view of a form a care provider would use to author a medication for a specific condition. With the patient in context, you can drill down into the specific (if any) conditions the patient has. Additionally, you can choose from an extensive list of medications to prescribe, and adjust dosage instructions accordingly. Any action taken on this view once a medication is prescribed will invoke the configured CDS Services on this tool listening on the `medication-prescribe` hook.
    
 ### Tools
 
 The Sandbox contains different tools to test and configure CDS Services. Below we describe each functionality and how to use it.
 
-- **Add CDS Service**: Configures your CDS Service(s) onto the Sandbox. Your services are discovered via the input of a discovery endpoint.
-- **Reset Configuration**: Resets the Sandbox to the original default configuration, which removes any added CDS Services and resets edited settings on the services.
-- **Configure CDS Services**: Edit settings on CDS Services configured (or add CDS Services here), and see what each service definition looks like (the response from invoking discovery endpoints).
+- **Add CDS Service**: Configures your CDS Service(s) onto the Sandbox. Your services are discovered via the input of a discovery endpoint. Note: The Sandbox may cache these services and persist them on a refresh of the page.
+- **Reset Default Services**: Resets the Sandbox to the original default CDS Services and removes any added configured services. Any cached CDS Services will be removed.
+- **Configure CDS Services**: Edit settings on CDS Services configured, and see what each service definition looks like (the response from invoking discovery endpoints).
   - `Enabled` - Allow the Sandbox to interact with this specific CDS Service if enabled. Otherwise, ignore this service in the workflow of this tool.
   - `Delete` - Delete this specific CDS Service from the Sandbox entirely
-  - `Save` - Save any edited services or added services for the Sandbox
 
-- **CDS Service Exchange**: The right-hand panel of the screen displays the CDS Service context, or the CDS Service Exchange. For each CDS Service invoked (listed in the dropdown under "Select a Service"), the Sandbox will display collapsible panels that contain the specific request the Sandbox made to that CDS service, and the specific response (if any) the service returned to the Sandbox. This allows CDS Service providers testing their services to see what a request would look like to their services and what their response should look like to the EHR. This context information is also automatically logged on the developer console of the browser.
-- **Card Demo**: This feature located on the toolbar header allows developers to see how a card response renders on the UI in real-time. Developers can edit the service response JSON on the right-hand side and see the card render automatically with their changes on the left-hand side. This is useful to see how links/buttons/text render on the Sandbox so their own CDS Service responses can be adjusted accordingly. Note that each EHR vendor ultimately decides how to render cards stylistically, and the card generated on this tool may not reflect similar styles with other vendors.
+- **CDS Developer Panel**: The right-hand panel of the screen displays the CDS Service context, or the CDS Developer Panel. For each CDS Service invoked (listed in the dropdown under "Select a Service"), the Sandbox will display collapsible panels that contain the specific request the Sandbox made to that CDS service, and the specific response (if any) the service returned to the Sandbox. This allows CDS Service providers testing their services to see what a request would look like to their services and what their response should look like to the EHR.
+- **Card Demo**: This feature located on the toolbar header (the pencil icon) allows developers to see how a card response renders on the UI in real-time. Developers can edit the service response JSON on the right-hand side and see the card render automatically with their changes on the left-hand side. This is useful to see how links/buttons/text render on the Sandbox so their own CDS Service responses can be adjusted accordingly. Note that each EHR vendor ultimately decides how to render cards stylistically, and the card generated on this tool may not reflect similar styles with other vendors.
 
-The tool also allows for testing against different patients and FHIR servers.
-- **Change Patient** - This feature located on the toolbar header allows users to change the patient in context of the tool by inputting the patient ID of a patient (as it relates to the FHIR server in context). If the default FHIR server is enabled, a list of different patients will be available to choose from.
-- **Change FHIR Server** - This feature located on the toolbar header allows users to test the Sandbox against a FHIR server of their choice by inputting a FHIR server URL. Additionally, the user can reset to testing against the default FHIR server here. Currently, the Sandbox only allows testing against an open endpoint of a FHIR server. However, the Sandbox supports testing against secured FHIR servers from HSPC sandbox instances; see below for more details.
+The tool also allows for testing against different patients and FHIR servers (see gear icon on the toolbar header).
+- **Change Patient** - This feature allows users to change the patient in context of the tool by inputting the patient ID of a patient (as it relates to the FHIR server in context). Note: The Sandbox may cache this patient ID and persist this configuration on a refresh of the page.
+- **Change FHIR Server** - This feature located on the toolbar header allows users to test the Sandbox against a FHIR server of their choice by inputting a FHIR server URL. Additionally, the user can reset to testing against the default FHIR server here. Currently, the Sandbox **only allows testing against an open endpoint of a FHIR server**. However, the Sandbox supports testing against secured FHIR servers from HSPC sandbox instances; see below for more details. Note: The Sandbox may cache this FHIR server and persist this configuration on a refresh of the page.
 
 ## Testing w/ Secured FHIR Servers
 
-Currently, launching the Sandbox by simply navigating to `http://sandbox.cds-hooks.org` means the tool can only be tested against an open FHIR server endpoint. However, the Sandbox tool can be launched as a SMART application from an [HSPC sandbox instance](https://sandbox.hspconsortium.org), and the tool can then test against a secured FHIR server endpoint. This endpoint would be the FHIR server of the HSPC sandbox instance the CDS Hooks Sandbox is launched from. By default, an app is configured on each HSPC sandbox, CDS Hooks Sandbox, which allows users to launch the Sandbox as a SMART app from their own HSPC instance and test the Sandbox against a secured FHIR endpoint.
+Currently, launching the Sandbox by simply navigating to `https://cds-hooks.github.io/sandbox-2.0` means the tool can only be tested against an open FHIR server endpoint. However, the Sandbox tool can be launched as a SMART application from an [HSPC sandbox instance](https://sandbox.hspconsortium.org), and the tool can then test against a secured FHIR server endpoint. This endpoint would be the FHIR server of the HSPC sandbox instance the CDS Hooks Sandbox is launched from. By default, an app is configured on each HSPC sandbox, which allows users to launch the Sandbox as a SMART app from their own HSPC instance and test the Sandbox against a secured FHIR endpoint. Additionally, if the Sandbox is launched against a secured HSPC FHIR endpoint, it can also launch SMART apps from Card links securely as well.
+
+To test the Sandbox against a secured FHIR server, see steps below.
+
+1. If you have not done so before, create an [HSPC Sandbox account](https://sandbox.hspconsortium.org/#/start).
+2. Click the button "Create Sandbox" and follow the prompts. Make sure to check the box "Allow Open FHIR Endpoint" and "Apply Default Data Set". 
+3. On the "Apps" page, launch the "CDS Hooks Sandbox" app, and choose a patient to launch with.
+
+The Sandbox should automatically launch in a new tab, and the configured FHIR server (secured endpoint) should be that of the HSPC Sandbox that launched it.  
 
 Note: When launching the Sandbox in this manner, the option to change the FHIR server in context is removed from the tool. This is because the Sandbox will be passed an `access_token` when launched as a SMART application from HSPC. This token will be passed to CDS Services in requests, and used to query the FHIR server for any additional extra queries down the workflow.
 
-## Local development
+## Local Development
 
-You can develop on and run this project locally by using the following steps below. There are two means of developing: with and without Docker.
+You can develop on and run this project locally by using the following steps below. 
 
-### Development without Docker (recommended)
+### Setup
 
-#### Setup
-
-Install `nodejs` 6.11+ and `npm` 5.0+ on your machine and then install the project and its dependencies locally:
+If you don't already have it, install the [LTS version](https://nodejs.org/en/download/) of `Node.js` on your machine and then install the project and its dependencies locally via the steps below in your terminal/shell:
 ```
-git clone https://github.com/cds-hooks/sandbox.git
+git clone https://github.com/cds-hooks/sandbox-2.0.git
 cd sandbox
 npm install
 ```
 
-#### Run it
+### Run it
 
-To load the webpage, run the following command:
+To load the application on localhost, run the following command at the top-level of the project directory:
 ```
-npm run dev-frontend
-```
-
-To run the mock CDS services that accompany this tool, run the following command:
-```
-npm run dev-services
+npm run dev
 ```
 
 Now, you can navigate to `http://localhost:8080` to view the application. Any changes made to the code locally should be
 picked up automatically by the `webpack-dev-server`, and you should see the changes reflect accordingly.
 
-### Development with Docker
+### Linting
 
-1. Install latest (1.9+) `docker-engine` (see
-https://docs.docker.com/engine/installation/ubuntulinux/)
-
-2. Install latest (1.5.2+) `docker-compose` (see
-https://docs.docker.com/compose/install/)
-
-For me, on Ubuntu 15.10, this meant running:
-
+This project uses [ESLint](https://eslint.org/) to do a static analysis of the code and make sure it adheres to specific style guidelines. To lint, run the following command at the top-level of the project directory:
 ```
-echo "deb https://apt.dockerproject.org/repo ubuntu-wily main" |  sudo tee --append /etc/apt/sources.list.d/docker.list
-sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
-sudo apt-get update
-sudo apt-get install docker-engine pip
-sudo pip install docker-compose
+npm run lint
 ```
 
-#### Local dev environment w/ Docker
+Note: This command will be run on each pull request to this repository, and any added code MUST pass the linter before being merged in.
 
+### Testing
+
+This project uses [Jest](https://facebook.github.io/jest/) to unit test the application. This includes the actions, reducers, middleware, data retrieval funtions, and components. To test, run the following command at the top-level of the project directory:
 ```
-git clone https://github.com/cds-hooks/sandbox.git
-cd sandbox
-sudo docker-compose -f docker-compose-dev.yml  up
-```
-
-From here, once the server builds and comes online you can edit files in `src`
-and see changes automatically reloaded at `http://localhost:8080`
-
-Configuration:
-
- * To talk to a FHIR server other than `https://api.hspconsortium.org/cdshooksdstu2/open`,
-   you can pass a query variable to the HTML page, as in
-   `http://localhost:8080?fhirServiceUrl=http://my-fhir-server`
-
-Bring up the whole stack including API server, assuming you're on a host called `morel`:
-
-```
-CDS_HOOKS_URL="http://morel:9001" \
-FHIR_URL="http://morel:9002/data" \
-docker-compose -f docker-compose-dev.yml up
+npm run test
 ```
 
-## Build and Contribution
+Note: This command will be run on each pull request to this repository, and any added code MUST pass at least the existing tests before being merged in.
 
-We welcome any contributions to help further enhance this tool for the CDS Hooks community! To contribute to this project, please see instructions above for running the application locally and testing the app to make sure the tool works as expected with your incorporated changes. Then follow the steps below.
+## Contributing
 
-1. At the root level of the project, run `npm run build` to bundle the application code. Please ensure no errors occur during this step.
-2. Issue a pull request on the `cds-hooks/Sandbox` repository with your changes for review. 
+We welcome any contributions to help further enhance this tool for the CDS Hooks community! To contribute to this project, please see instructions above for running the application locally and testing the app to make sure the tool works as expected with your incorporated changes. Follow the steps below to get started.
+
+1. [Fork this project](https://help.github.com/articles/fork-a-repo/) to make a copy of this repository onto your own Github profile
+1. Make necessary code changes onto your forked project and run the application locally to ensure expected behavior
+2. Lint and test the code changes to guarantee the project is maintained moving forward 
+3. Issue a pull request on the `cds-hooks/Sandbox-2.0` repository with your changes for review
+4. Make any changes/revisions (as necessary)
+5. The project maintainers will merge the pull request in once approved


### PR DESCRIPTION
Updating the README here for better local development instructions and up-to-date descriptions of the tool. Will swap the https://cds-hooks.github.io/sandbox-2.0 url when we replace the old sandbox with this project. 

@kpshek 