### PR TITLE
Add jku to the JWT header

### DIFF
--- a/src/retrieve-data-helpers/jwt-generator.js
+++ b/src/retrieve-data-helpers/jwt-generator.js
@@ -16,6 +16,7 @@ function generateJWT(audience) {
     alg: 'ES256',
     typ: 'JWT',
     kid: 'd9cd3c4f-eb08-4304-b973-44f352fd2ca2',
+    jku: 'https://raw.githubusercontent.com/cds-hooks/sandbox-2.0/master/keys/jwk-keypair.json',
   });
 
   return JWT.jws.JWS.sign(null, jwtHeader, jwtPayload, privKey);

--- a/tests/retrieve-data-helpers/jwt-generator.test.js
+++ b/tests/retrieve-data-helpers/jwt-generator.test.js
@@ -32,6 +32,7 @@ describe('JWT Generator', () => {
       alg: 'ES256',
       typ: 'JWT',
       kid: 'd9cd3c4f-eb08-4304-b973-44f352fd2ca2',
+      jku: 'https://raw.githubusercontent.com/cds-hooks/sandbox-2.0/master/keys/jwk-keypair.json'
     });
     expect(generateJWT(audience)).toEqual(signedJwtMock);
     expect(signMethodMock).toHaveBeenCalledWith(null, expectedHeader, expectedPayload, mockPrivateKey);


### PR DESCRIPTION
We should be adding the `jku` header value to the JWT since we offer the keypair as a JWK Set. This fixes #20