### PR TITLE
Change medications field in context for medication-prescribe to be a FHIR bundle with the medication order. Fixes #19

### DIFF
--- a/src/components/RxView/rx-view.jsx
+++ b/src/components/RxView/rx-view.jsx
@@ -126,10 +126,14 @@ export class RxView extends Component {
     if (Object.keys(this.props.services).length) {
       // For each service, call service for request/response exchange
       forIn(this.props.services, (val, key) => {
-        // TODO: Once default services are fixed to parse FHIR bundle, change this to FHIR bundle format
         const context = [{
           key: 'medications',
-          value: [this.props.medicationOrder],
+          value: {
+            resourceType: 'Bundle',
+            entry: [{
+              resource: this.props.medicationOrder,
+            }],
+          },
         }];
         callServices(key, context);
       });

--- a/tests/components/RxView/rx-view.test.js
+++ b/tests/components/RxView/rx-view.test.js
@@ -22,7 +22,7 @@ describe('RxView component', () => {
   let prescription;
 
   let chooseCondition, onMedicationChangeInput, chooseMedication,
-  updateDosageInstructions, updateDate, toggleEnabledDate, updateFhirResource;
+  updateDosageInstructions, updateDate, toggleEnabledDate, updateFhirResource, medicationOrder;
 
   function setup(patient, medListPhase, prescription) {
     jest.setMock('../../../src/retrieve-data-helpers/service-exchange', mockSpy);
@@ -49,7 +49,8 @@ describe('RxView component', () => {
         services={services} hook={'medication-prescribe'} medListPhase={medListPhase} 
         medications={medications} prescription={prescription} onMedicationChangeInput={onMedicationChangeInput} 
         chooseMedication={chooseMedication} chooseCondition={chooseCondition} updateDosageInstructions={updateDosageInstructions} 
-        updateDate={updateDate} toggleEnabledDate={toggleEnabledDate} updateFhirResource={updateFhirResource} />;
+        updateDate={updateDate} toggleEnabledDate={toggleEnabledDate} updateFhirResource={updateFhirResource}
+        medicationOrder={medicationOrder} />;
     renderedComponent = shallow(component, intlContexts.shallowContext);
   }
 
@@ -85,6 +86,7 @@ describe('RxView component', () => {
       id: '345',
     };
     medListPhase = 'begin';
+    medicationOrder = { foo: 'foo' };
     mockSpy = jest.fn();
     chooseCondition = jest.fn();
     onMedicationChangeInput = jest.fn(); 
@@ -162,6 +164,15 @@ describe('RxView component', () => {
     let newComponent = await renderedComponent.setProps({ prescription: prescription });
     Promise.resolve(newComponent).then(() => {
       expect(mockSpy).toHaveBeenCalledTimes(2);
+      expect(mockSpy).toHaveBeenCalledWith('http://example.com/cds-services/id-1', [{
+        key: 'medications',
+        value: {
+          resourceType: 'Bundle',
+          entry: [{
+            resource: medicationOrder,
+          }],
+        },
+      }]);
       done();
     });
   });


### PR DESCRIPTION
Currently, a medication selected in the RxView is included in the context of a service request as MedicationOrder/MedicationRequest resources in an array. This proposes to switch the `medications` context field to align with the 1.0 spec for `medication-prescribe`, where the medications are resource entries in a FHIR bundle. 

@kpshek 