### PR TITLE
Add fhirAuthorization field to service request if applicable. Switch current production client ID for Sandbox to old Sandbox production client ID. Fixes #22

### DIFF
--- a/src/config/fhir-config.js
+++ b/src/config/fhir-config.js
@@ -1,5 +1,5 @@
 // CDS Hooks DSTU2 HSPC Sandbox - https://sandbox.cds-hooks.org/launch.html
-export const productionClientId = '36600f19-a0de-4dcc-bf04-db30d8b09e8f';
+export const productionClientId = '48163c5e-88b5-4cb3-92d3-23b800caa927';
 
 // CDS Hooks DSTU2 HSPC Sandbox - http://localhost:8080/launch.html
 export const localhostClientId = '99407c8a-3069-41b1-af07-2612bc1f99de';

--- a/src/retrieve-data-helpers/service-exchange.js
+++ b/src/retrieve-data-helpers/service-exchange.js
@@ -2,6 +2,7 @@ import axios from 'axios';
 import queryString from 'query-string';
 import store from '../store/store';
 import { storeExchange } from '../actions/service-exchange-actions';
+import { productionClientId, allScopes } from '../config/fhir-config';
 import generateJWT from './jwt-generator';
 
 const uuidv4 = require('uuid/v4');
@@ -109,6 +110,17 @@ function callServices(url, context) {
   }
 
   const hookInstance = uuidv4();
+  const accessTokenProperty = store.getState().fhirServerState.accessToken;
+  let fhirAuthorization;
+  if (accessTokenProperty) {
+    fhirAuthorization = {
+      access_token: accessTokenProperty.access_token,
+      token_type: 'Bearer',
+      expires_in: accessTokenProperty.expires_in,
+      scope: allScopes,
+      subject: productionClientId,
+    };
+  }
   const request = {
     hookInstance,
     hook,
@@ -117,6 +129,10 @@ function callServices(url, context) {
     patient,
     context: activityContext,
   };
+
+  if (fhirAuthorization) {
+    request.fhirAuthorization = fhirAuthorization;
+  }
 
   const serviceDefinition = state.cdsServicesState.configuredServices[url];
 

--- a/tests/retrieve-data-helpers/service-exchange.test.js
+++ b/tests/retrieve-data-helpers/service-exchange.test.js
@@ -57,7 +57,7 @@ describe('Service Exchange', () => {
     mockHookInstance = '123';
     mockAccessToken = {
       access_token: 'access-token',
-      expires_in: 'now',
+      expires_in: '600',
     }
     mockRequest = {
       hookInstance: mockHookInstance,

--- a/tests/retrieve-data-helpers/service-exchange.test.js
+++ b/tests/retrieve-data-helpers/service-exchange.test.js
@@ -8,6 +8,7 @@ describe('Service Exchange', () => {
   let mockAxios;
   let axios;
   let actions;
+  let fhirConfig;
 
   let mockStore = {};
   let defaultStore = {};
@@ -22,6 +23,8 @@ describe('Service Exchange', () => {
   let mockHookInstance;
   let mockRequest;
   let mockRequestWithContext;
+  let mockRequestWithFhirAuthorization;
+  let mockAccessToken;
 
   let noDataMessage = 'No response returned. Check developer tools for more details.';
   let failedServiceCallMessage = 'Could not get a response from the CDS Service. See developer tools for more details';
@@ -44,6 +47,7 @@ describe('Service Exchange', () => {
   }
 
   beforeEach(() => {
+    fhirConfig = require('../../src/config/fhir-config');
     mockPatient = 'patient-1';
     mockFhirServer = 'http://fhir-server-example.com';
     mockServiceWithPrefetch = 'http://example.com/cds-services/id-1';
@@ -51,6 +55,10 @@ describe('Service Exchange', () => {
     mockServiceNoEncoding = 'http://example.com/cds-services/id-3';
     mockServiceWithPrefetchEncoded = 'http://example.com/cds-services/id-4';
     mockHookInstance = '123';
+    mockAccessToken = {
+      access_token: 'access-token',
+      expires_in: 'now',
+    }
     mockRequest = {
       hookInstance: mockHookInstance,
       hook: 'patient-view',
@@ -65,6 +73,15 @@ describe('Service Exchange', () => {
         medications: [{
           foo: 'foo',
         }],
+      },
+    });
+    mockRequestWithFhirAuthorization = Object.assign({}, mockRequest, {
+      fhirAuthorization: {
+        access_token: mockAccessToken.access_token,
+        token_type: 'Bearer',
+        expires_in: mockAccessToken.expires_in,
+        scope: fhirConfig.allScopes,
+        subject: fhirConfig.productionClientId,
       },
     });
 
@@ -122,16 +139,17 @@ describe('Service Exchange', () => {
       });
 
       it('resolves and dispatches a successful CDS Service call when prefetch is retrieved', () => {
-        defaultStore.fhirServerState.accessToken = { access_token: 'mock-access-token' };
+        defaultStore.fhirServerState.accessToken = mockAccessToken;
+        mockRequestWithFhirAuthorization.prefetch = {test: {resource: prefetchedData, response: {status: 200}}};
         const serviceResultStatus = 200;
         mockAxios.onGet(`${mockFhirServer}/Observation?code=${encodeURIComponent('http://loinc.org|2857-1')}&patient=${mockPatient}`)
           .reply((config) => {
-            expect(config.headers['Authorization']).toEqual('Bearer mock-access-token');
+            expect(config.headers['Authorization']).toEqual(`Bearer ${mockAccessToken.access_token}`);
             return [200, prefetchedData];
           })
           .onPost(mockServiceWithPrefetch).reply(serviceResultStatus, mockServiceResult);
         return callServices(mockServiceWithPrefetch).then(() => {
-          expect(spy).toHaveBeenCalledWith(mockServiceWithPrefetch, mockRequest, mockServiceResult, serviceResultStatus);
+          expect(spy).toHaveBeenCalledWith(mockServiceWithPrefetch, mockRequestWithFhirAuthorization, mockServiceResult, serviceResultStatus);
         });
       });
 


### PR DESCRIPTION
We should allow the Sandbox to add the `fhirAuthorization` field to service requests if the Sandbox is launched securely and receives an access token. The spec states that `subject` is the OAuth 2.0 client identifier of the CDS Service. For now, we could use the client ID of the Sandbox (that was used to launch as a SMART app against HSPC) as that `subject` field. 

Additionally, this proposes to switch the current production client ID of the Sandbox to the production client ID of the old Sandbox. This way, when `sandbox.cds-hooks.org` points to this project, there's no additional work on the HSPC end to re-configure a default CDS Hooks Sandbox app for each HSPC user with a new client ID. 
