### PR TITLE
Change current prefetch template syntax to align with context-based properties for 1.0 spec. Fixes #21

### DIFF
--- a/src/retrieve-data-helpers/service-exchange.js
+++ b/src/retrieve-data-helpers/service-exchange.js
@@ -37,8 +37,8 @@ function completePrefetchTemplate(prefetch) {
   const prefetchRequests = Object.assign({}, prefetch);
   Object.keys(prefetchRequests).forEach((prefetchKey) => {
     let prefetchTemplate = prefetchRequests[prefetchKey];
-    prefetchTemplate = prefetchTemplate.replace(/{{\s*Patient\.id\s*}}/g, patient);
-    prefetchTemplate = prefetchTemplate.replace(/{{\s*User\.id\s*}}/g, user);
+    prefetchTemplate = prefetchTemplate.replace(/{{\s*context\.patientId\s*}}/g, patient);
+    prefetchTemplate = prefetchTemplate.replace(/{{\s*user\s*}}/g, user);
     prefetchRequests[prefetchKey] = encodeUriParameters(prefetchTemplate);
   });
   return prefetchRequests;

--- a/tests/retrieve-data-helpers/service-exchange.test.js
+++ b/tests/retrieve-data-helpers/service-exchange.test.js
@@ -83,19 +83,19 @@ describe('Service Exchange', () => {
         configuredServices: {
           [`${mockServiceWithPrefetch}`]: {
             prefetch: {
-              test: 'Observation?patient={{Patient.id}}&code=http://loinc.org|2857-1'
+              test: 'Observation?patient={{context.patientId}}&code=http://loinc.org|2857-1'
             }
           },
           [`${mockServiceWithPrefetchEncoded}`]: {
             prefetch: {
-              first: 'Conditions?patient={{Patient.id}}',
-              test: `Observation?patient={{Patient.id}}&code=${encodeURIComponent('http://loinc.org|2857-1')}`,
-              second: 'Patient/{{Patient.id}}'
+              first: 'Conditions?patient={{context.patientId}}',
+              test: `Observation?patient={{context.patientId}}&code=${encodeURIComponent('http://loinc.org|2857-1')}`,
+              second: 'Patient/{{context.patientId}}'
             }
           },
           [`${mockServiceNoEncoding}`]: {
             prefetch: {
-              test: 'Patient/{{Patient.id}}'
+              test: 'Patient/{{context.patientId}}'
             }
           },
           [`${mockServiceWithoutPrefetch}`]: {}


### PR DESCRIPTION
Currently, the prefetch templates that are interpreted by the Sandbox are based off an older syntax, using pre-defined templates like `{{Patient.id}}` and `{{User.id}}`. To align the Sandbox with the 1.0 spec, we should fix this to use the new hook-defined prefetch templates, such that they match their `context` property counterparts. So the above would be revised to parse `{{context.patientId}}` and `{{user}}`. Since for now the Sandbox only supports `patient-view` and `medication-prescribe`, the examples above would be the only prefetch templates that the Sandbox may interpret from CDS Service definitions. 