### PR TITLE
Add additional FHIR server input validation by checking for secure FHIR endpoint user inputs and displaying an error accordingly. Also grabbing localStorage values inside the data retrieval methods themselves

### DIFF
--- a/src/reducers/fhir-server-reducers.js
+++ b/src/reducers/fhir-server-reducers.js
@@ -2,7 +2,7 @@ import * as types from '../actions/action-types';
 
 const initialState = {
   testFhirServer: null,
-  currentFhirServer: 'https://api.hspconsortium.org/cdshooksdstu2/open',
+  currentFhirServer: '',
   currentMetadata: null,
   defaultFhirServer: 'https://api.hspconsortium.org/cdshooksdstu2/open',
   fhirVersion: '1.0.2',

--- a/src/retrieve-data-helpers/fhir-metadata-retrieval.js
+++ b/src/retrieve-data-helpers/fhir-metadata-retrieval.js
@@ -13,20 +13,41 @@ function retrieveFhirMetadata(testUrl) {
     let testFhirServer = testUrl;
     if (!testFhirServer) {
       const parsed = queryString.parse(window.location.search);
-      testFhirServer = parsed.fhirServiceUrl || store.getState().fhirServerState.defaultFhirServer;
+      testFhirServer = parsed.fhirServiceUrl ||
+        localStorage.getItem('PERSISTED_fhirServer') ||
+        store.getState().fhirServerState.defaultFhirServer;
     }
-    const headers = { Accept: 'application/json+fhir' };
+    const headers = { Accept: 'application/json' };
     store.dispatch(setTestFhirServer(testFhirServer));
+    // Call metadata to check if there is a valid FHIR server, then hit a Patient endpoint to see
+    // if the server is a secured endpoint (checking for 401 errors). If so, then the Sandbox triggers a face-up error to the
+    // user that an open-launched Sandbox should be configured with an open FHIR endpoint
     axios({
       method: 'get',
       url: `${testFhirServer}/metadata`,
       headers,
-    }).then((result) => {
-      if (result.data && Object.keys(result.data).length) {
-        store.dispatch(signalSuccessFhirServerRetrieval(testFhirServer, result.data));
-        return resolve();
-      }
-      return reject();
+    }).then((metadataResult) => {
+      axios({
+        method: 'get',
+        url: `${testFhirServer}/Patient`,
+        headers,
+        validateStatus: status => status !== 401,
+      }).then(() => {
+        if (metadataResult.data && Object.keys(metadataResult.data).length) {
+          store.dispatch(signalSuccessFhirServerRetrieval(testFhirServer, metadataResult.data));
+          return resolve();
+        }
+        return reject();
+      }).catch((err) => {
+        if (err.response && err.response.status === 401) {
+          console.error('Cannot use secured FHIR endpoint on an open-launched Sandbox. See https://github.com/cds-hooks/sandbox-2.0#testing-w-secured-fhir-servers' +
+          ' for more details on testing the Sandbox against a secured FHIR endpoint.');
+        } else {
+          console.error('Could not connect to metadata endpoint of the FHIR server', err);
+        }
+        store.dispatch(signalFailureFhirServerRetrieval());
+        return reject(err);
+      });
     }).catch((err) => {
       console.error('Could not connect to metadata endpoint of the FHIR server', err);
       store.dispatch(signalFailureFhirServerRetrieval());

--- a/src/retrieve-data-helpers/patient-retrieval.js
+++ b/src/retrieve-data-helpers/patient-retrieval.js
@@ -26,7 +26,9 @@ function retrievePatient(testPatient) {
       headers.Authorization = `Bearer ${accessToken.access_token}`;
     } else if (!patient) {
       const parsed = queryString.parse(window.location.search);
-      patient = parsed.patientId || store.getState().patientState.defaultPatientId;
+      patient = parsed.patientId ||
+        localStorage.getItem('PERSISTED_patientId') ||
+        store.getState().patientState.defaultPatientId;
     }
     axios({
       method: 'get',

--- a/tests/components/MainView/main-view.test.js
+++ b/tests/components/MainView/main-view.test.js
@@ -80,11 +80,14 @@ describe('MainView component', () => {
 
   it('opens a fhir server entry prompt if fhir server call failed', async (done) => {
     mockPromiseSmartCall = jest.fn(() => Promise.reject(0));
-    mockPromiseFhirCall = jest.fn(() => Promise.reject(0));
+    mockPromiseFhirCall = jest.fn(() => Promise.reject({
+      response: { status: 401 },
+    }));
     setup(storeState);
     let shallowedComponent = await pureComponent.shallow();
     Promise.resolve(shallowedComponent).then(() => {
       expect(shallowedComponent.state('fhirServerPrompt')).toEqual(true);
+      expect(shallowedComponent.state('fhirServerIntialResponse')).not.toEqual('');
       done();
     });
   });
@@ -133,30 +136,6 @@ describe('MainView component', () => {
       setup(storeState);
       const shallowedComponent = pureComponent.shallow();
       expect(mockStore.getActions()[1]).toEqual(setHook('patient-view'));
-    });
-
-    it('tries to configure a persisted FHIR server from localStorage', async (done) => {
-      mockPromiseSmartCall = jest.fn(() => Promise.reject(0));
-      const persistedFhirServer = 'http://persisted.com';
-      localStorage.setItem('PERSISTED_fhirServer', persistedFhirServer);
-      setup(storeState);
-      const shallowedComponent = await pureComponent.shallow();
-      Promise.resolve(shallowedComponent).then(() => {
-        expect(mockPromiseFhirCall).toHaveBeenCalledWith(localStorage.getItem('PERSISTED_fhirServer'));
-        done();
-      });
-    });
-
-    it('tries to configure a persisted Patient ID from localStorage', async (done) => {
-      mockPromisePatientCall = jest.fn(() => Promise.reject(0));
-      const persistedPatientId = '123';
-      localStorage.setItem('PERSISTED_patientId', persistedPatientId);
-      setup(storeState);
-      const shallowedComponent = await pureComponent.shallow();
-      Promise.resolve(shallowedComponent).then(async () => {
-        await expect(mockPromisePatientCall).toHaveBeenCalledWith(localStorage.getItem('PERSISTED_patientId'));
-        done();
-      });
     });
 
     it('tries to discover any CDS Services from local storage', async (done) => {

--- a/tests/reducers/fhir-server-reducers.test.js
+++ b/tests/reducers/fhir-server-reducers.test.js
@@ -6,7 +6,7 @@ describe('FHIR Server Reducers', () => {
 
   beforeEach(() => {
     state = {
-      currentFhirServer: 'https://api.hspconsortium.org/cdshooksdstu2/open',
+      currentFhirServer: '',
       currentMetadata: null,
       defaultFhirServer: 'https://api.hspconsortium.org/cdshooksdstu2/open',
       fhirVersion: '1.0.2',

--- a/tests/retrieve-data-helpers/patient-retrieval.test.js
+++ b/tests/retrieve-data-helpers/patient-retrieval.test.js
@@ -81,6 +81,20 @@ describe('Patient Retrieval', () => {
       });
     });
 
+    it('resolves and dispatches a success action with patient from localStorage', () => {
+      const persistedPatientId = 'default-patient-id';
+      localStorage.setItem('PERSISTED_patientId', persistedPatientId);
+      setMocksAndTestFunction(defaultStore);
+      mockAxios.onGet(`${fhirServer}/Patient/${persistedPatientId}`)
+        .reply(200, expectedPatient);
+      const spy = jest.spyOn(actions, 'signalSuccessPatientRetrieval');
+      return retrievePatient().then(() => {
+        expect(spy).toHaveBeenCalledWith(expectedPatient);
+        spy.mockReset();
+        spy.mockRestore();
+      }); 
+    });
+
     it('resolves and dispatches a success action with passed in patient despite access token patient being set', () => {
       setMocksAndTestFunction(Object.assign({}, defaultStore, {
         fhirServerState: {


### PR DESCRIPTION
Currently, a user can input a secured FHIR server via the `fhirServiceUrl` param in the URL, or on the settings button at "Change FHIR Server". Since the only validation being done is hitting the metadata endpoint, both an open and secured endpoint will succeed the check and then move to a patient ID input. 

We should do extra validation to ensure that the FHIR server being inputted is an open endpoint by checking if hitting a `/Patient` endpoint results in a 401 (Unauthorized). If so, the user won't proceed in choosing a patient, and an appropriate message will be displayed on the modal. For example, if the user tries to put in a secured FHIR endpoint like `https://api.hspconsortium.org/cdshooksdstu2/data`, the result will be a 401 error, and an error will popup asking them to input an open endpoint.

Additionally, moving the localStorage rehydration inside the data retrieval methods, so that access token values or values in the URL (i.e. `fhirServiceUrl` or `patientId`) will take precedence over the localStorage values.