### PR TITLE
Add button on settings menu to clear cached Sandbox configuration

### DIFF
--- a/src/components/Header/header.jsx
+++ b/src/components/Header/header.jsx
@@ -51,6 +51,7 @@ export class Header extends Component {
     this.closeChangeFhirServer = this.closeChangeFhirServer.bind(this);
     this.openConfigureServices = this.openConfigureServices.bind(this);
     this.closeConfigureServices = this.closeConfigureServices.bind(this);
+    this.clearCache = this.clearCache.bind(this);
 
     this.resetServices = this.resetServices.bind(this);
   }
@@ -74,6 +75,16 @@ export class Header extends Component {
   resetServices() {
     this.props.resetServices();
     retrieveDiscoveryServices();
+    this.closeSettingsMenu();
+  }
+
+  clearCache() {
+    // Temporary removal until all persisted values are refactored into one localStorage property
+    localStorage.removeItem('PERSISTED_cdsServices');
+    localStorage.removeItem('PERSISTED_fhirServer');
+    localStorage.removeItem('PERSISTED_hook');
+    localStorage.removeItem('PERSISTED_patientId');
+    this.closeSettingsMenu();
   }
 
   openConfigureServices() {
@@ -113,7 +124,7 @@ export class Header extends Component {
 
   render() {
     const logo = <div><span><img src={cdsHooksLogo} alt="" height="30" width="30" /></span><b className={styles['logo-title']}>CDS Hooks Sandbox</b></div>;
-    const menuItems = [
+    let menuItems = [
       <Menu.Item text="Add CDS Services" key="add-services" onClick={this.openAddServices} />,
       <Menu.Item text="Reset Default Services" key="reset-services" onClick={this.resetServices} />,
       <Menu.Item text="Configure CDS Services" key="configure-services" onClick={this.openConfigureServices} />,
@@ -123,6 +134,10 @@ export class Header extends Component {
     if (!this.props.isSecuredSandbox) {
       menuItems.push(<Menu.Item text="Change FHIR Server" key="change-fhir-server" onClick={this.openChangeFhirServer} />);
     }
+    menuItems = menuItems.concat([
+      <Menu.Divider key="Divider2" />,
+      <Menu.Item text="Clear Cached Configuration" key="clear-cached-configuration" onClick={this.clearCache} />,
+    ]);
     const gearMenu = (
       <Menu
         isOpen={this.state.settingsOpen}

--- a/src/components/Header/header.jsx
+++ b/src/components/Header/header.jsx
@@ -18,6 +18,7 @@ import FhirServerEntry from '../FhirServerEntry/fhir-server-entry';
 
 import retrievePatient from '../../retrieve-data-helpers/patient-retrieval';
 import retrieveDiscoveryServices from '../../retrieve-data-helpers/discovery-services-retrieval';
+import retrieveFhirMetadata from '../../retrieve-data-helpers/fhir-metadata-retrieval';
 import { setHook } from '../../actions/hook-actions';
 import { toggleDemoView } from '../../actions/card-demo-actions';
 import { resetServices } from '../../actions/cds-services-actions';
@@ -51,9 +52,8 @@ export class Header extends Component {
     this.closeChangeFhirServer = this.closeChangeFhirServer.bind(this);
     this.openConfigureServices = this.openConfigureServices.bind(this);
     this.closeConfigureServices = this.closeConfigureServices.bind(this);
-    this.clearCache = this.clearCache.bind(this);
 
-    this.resetServices = this.resetServices.bind(this);
+    this.resetConfiguration = this.resetConfiguration.bind(this);
   }
 
   shouldComponentUpdate(nextProps) {
@@ -72,19 +72,21 @@ export class Header extends Component {
   openSettingsMenu() { this.setState({ settingsOpen: true }); }
 
   switchHook(hook) { this.props.setHook(hook); }
-  resetServices() {
+
+  async resetConfiguration() {
+    // Temporary removal until all persisted values are refactored into one localStorage property
+    this.closeSettingsMenu();
+    localStorage.removeItem('PERSISTED_cdsServices');
     this.props.resetServices();
     retrieveDiscoveryServices();
-    this.closeSettingsMenu();
-  }
 
-  clearCache() {
-    // Temporary removal until all persisted values are refactored into one localStorage property
-    localStorage.removeItem('PERSISTED_cdsServices');
     localStorage.removeItem('PERSISTED_fhirServer');
+    await retrieveFhirMetadata();
+
     localStorage.removeItem('PERSISTED_hook');
+
     localStorage.removeItem('PERSISTED_patientId');
-    this.closeSettingsMenu();
+    await retrievePatient();
   }
 
   openConfigureServices() {
@@ -125,18 +127,17 @@ export class Header extends Component {
   render() {
     const logo = <div><span><img src={cdsHooksLogo} alt="" height="30" width="30" /></span><b className={styles['logo-title']}>CDS Hooks Sandbox</b></div>;
     let menuItems = [
-      <Menu.Item text="Add CDS Services" key="add-services" onClick={this.openAddServices} />,
-      <Menu.Item text="Reset Default Services" key="reset-services" onClick={this.resetServices} />,
-      <Menu.Item text="Configure CDS Services" key="configure-services" onClick={this.openConfigureServices} />,
-      <Menu.Divider key="Divider1" />,
-      <Menu.Item text="Change Patient" key="change-patient" onClick={this.openChangePatient} />,
+      <Menu.Item className={styles['add-services']} text="Add CDS Services" key="add-services" onClick={this.openAddServices} />,
+      <Menu.Item className={styles['configure-services']} text="Configure CDS Services" key="configure-services" onClick={this.openConfigureServices} />,
+      <Menu.Divider className={styles['divider-1']} key="Divider1" />,
+      <Menu.Item className={styles['change-patient']} text="Change Patient" key="change-patient" onClick={this.openChangePatient} />,
     ];
     if (!this.props.isSecuredSandbox) {
-      menuItems.push(<Menu.Item text="Change FHIR Server" key="change-fhir-server" onClick={this.openChangeFhirServer} />);
+      menuItems.push(<Menu.Item className={styles['change-fhir-server']} text="Change FHIR Server" key="change-fhir-server" onClick={this.openChangeFhirServer} />);
     }
     menuItems = menuItems.concat([
-      <Menu.Divider key="Divider2" />,
-      <Menu.Item text="Clear Cached Configuration" key="clear-cached-configuration" onClick={this.clearCache} />,
+      <Menu.Divider className={styles['divider-2']} key="Divider2" />,
+      <Menu.Item className={styles['reset-configuration']} text="Reset Configuration" key="reset-configuration" onClick={this.resetConfiguration} />,
     ]);
     const gearMenu = (
       <Menu

--- a/tests/components/Header/header.test.js
+++ b/tests/components/Header/header.test.js
@@ -1,4 +1,6 @@
 jest.mock('../../../src/retrieve-data-helpers/discovery-services-retrieval', () => {return jest.fn();});
+jest.mock('../../../src/retrieve-data-helpers/fhir-metadata-retrieval', () => {return jest.fn();});
+jest.mock('../../../src/retrieve-data-helpers/patient-retrieval', () => {return jest.fn();});
 
 import React from 'react';
 import { shallow, mount } from 'enzyme';
@@ -67,7 +69,7 @@ describe('Header component', () => {
 
   it('should display option to change FHIR server if no access token is configured for the application', () => {
     shallowedComponent.childAt(0).dive().find('.icon').first().simulate('click');
-    expect(shallowedComponent.find('Menu').childAt(5).key()).toEqual('change-fhir-server');
+    expect(shallowedComponent.find('Menu').find('.change-fhir-server').key()).toEqual('change-fhir-server');
   });
 
   it('should not display option to change FHIR server if an access token is configured for the application', () => {
@@ -84,7 +86,7 @@ describe('Header component', () => {
     shallowedComponent = shallow(component).find(Header).shallow();
 
     shallowedComponent.childAt(0).dive().find('.icon').first().simulate('click');
-    expect(shallowedComponent.find('Menu').childAt(5).key()).toEqual('Divider2');
+    expect(shallowedComponent.find('Menu').find('.change-fhir-server').length).toEqual(0);
   });
 
   describe('Change Patient', () => {
@@ -93,7 +95,7 @@ describe('Header component', () => {
     });
 
     it('should open the modal to change a patient if the Change Patient option is clicked directly', () => {
-      shallowedComponent.find('Menu').childAt(4).simulate('click');
+      shallowedComponent.find('Menu').find('.change-patient').simulate('click');
       expect(shallowedComponent.state('isChangePatientOpen')).toBeTruthy();
       expect(shallowedComponent.state('settingsOpen')).toBeFalsy();
       expect(shallowedComponent.find('Connect(PatientEntry)').length).toEqual(1);
@@ -106,7 +108,7 @@ describe('Header component', () => {
     });
 
     it('should open the modal to change the FHIR server if the Change FHIR Server option is clicked directly', () => {
-      shallowedComponent.find('Menu').childAt(5).simulate('click');
+      shallowedComponent.find('Menu').find('.change-fhir-server').simulate('click');
       expect(shallowedComponent.state('isChangeFhirServerOpen')).toBeTruthy();
       expect(shallowedComponent.state('settingsOpen')).toBeFalsy();
       expect(shallowedComponent.find('Connect(FhirServerEntry)').length).toEqual(1);
@@ -119,22 +121,10 @@ describe('Header component', () => {
     });
 
     it('should open the modal to add CDS Services if the Add Services option is clicked directly', () => {
-      shallowedComponent.find('Menu').childAt(0).simulate('click');
+      shallowedComponent.find('Menu').find('.add-services').simulate('click');
       expect(shallowedComponent.state('isAddServicesOpen')).toBeTruthy();
       expect(shallowedComponent.state('settingsOpen')).toBeFalsy();
       expect(shallowedComponent.find('ServicesEntry').length).toEqual(1);
-    });
-  });
-
-  describe('Reset Default Services', () => {
-    beforeEach(() => {
-      shallowedComponent.childAt(0).dive().find('.icon').first().simulate('click');
-    });
-
-    it('should open the modal to add CDS Services if the Add Services option is clicked directly', () => {
-      shallowedComponent.find('Menu').childAt(1).simulate('click');
-      expect(shallowedComponent.state('settingsOpen')).toBeFalsy();
-      expect(mockStore.getActions()).toEqual([{ type: types.RESET_SERVICES }]);
     });
   });
 
@@ -144,23 +134,24 @@ describe('Header component', () => {
     });
 
     it('should open the modal to add CDS Services if the Add Services option is clicked directly', () => {
-      shallowedComponent.find('Menu').childAt(2).simulate('click');
+      shallowedComponent.find('Menu').find('.configure-services').simulate('click');
       expect(shallowedComponent.state('isConfigureServicesOpen')).toBeTruthy();
       expect(shallowedComponent.state('settingsOpen')).toBeFalsy();
       expect(shallowedComponent.find('Connect(ConfigureServices)').length).toEqual(1);
     });
   });
 
-  describe('Clear Cached Configuration', () => {
+  describe('Reset Configuration', () => {
     beforeEach(() => {
       shallowedComponent.childAt(0).dive().find('.icon').first().simulate('click');
     });
 
-    it('should open the modal and clear cached services if the Clear Cached Configuration button is clicked', () => {
+    it('should open the modal and clear cached services if the Reset Configuration button is clicked', async () => {
       localStorage.setItem('PERSISTED_patientId', 'patient-123');
       expect(localStorage.getItem('PERSISTED_patientId')).toEqual('patient-123');
-      shallowedComponent.find('Menu').childAt(7).simulate('click');
+      await shallowedComponent.find('Menu').find('.reset-configuration').simulate('click');
       expect(shallowedComponent.state('settingsOpen')).toBeFalsy();
+      expect(mockStore.getActions()).toEqual([{ type: types.RESET_SERVICES }]);
       expect(localStorage.getItem('PERSISTED_patientId')).toEqual(null);
     });
   });

--- a/tests/components/Header/header.test.js
+++ b/tests/components/Header/header.test.js
@@ -67,7 +67,6 @@ describe('Header component', () => {
 
   it('should display option to change FHIR server if no access token is configured for the application', () => {
     shallowedComponent.childAt(0).dive().find('.icon').first().simulate('click');
-    expect(shallowedComponent.find('Menu').children().length).toEqual(6);
     expect(shallowedComponent.find('Menu').childAt(5).key()).toEqual('change-fhir-server');
   });
 
@@ -85,7 +84,7 @@ describe('Header component', () => {
     shallowedComponent = shallow(component).find(Header).shallow();
 
     shallowedComponent.childAt(0).dive().find('.icon').first().simulate('click');
-    expect(shallowedComponent.find('Menu').children().length).toEqual(5);
+    expect(shallowedComponent.find('Menu').childAt(5).key()).toEqual('Divider2');
   });
 
   describe('Change Patient', () => {
@@ -134,6 +133,7 @@ describe('Header component', () => {
 
     it('should open the modal to add CDS Services if the Add Services option is clicked directly', () => {
       shallowedComponent.find('Menu').childAt(1).simulate('click');
+      expect(shallowedComponent.state('settingsOpen')).toBeFalsy();
       expect(mockStore.getActions()).toEqual([{ type: types.RESET_SERVICES }]);
     });
   });
@@ -148,6 +148,20 @@ describe('Header component', () => {
       expect(shallowedComponent.state('isConfigureServicesOpen')).toBeTruthy();
       expect(shallowedComponent.state('settingsOpen')).toBeFalsy();
       expect(shallowedComponent.find('Connect(ConfigureServices)').length).toEqual(1);
+    });
+  });
+
+  describe('Clear Cached Configuration', () => {
+    beforeEach(() => {
+      shallowedComponent.childAt(0).dive().find('.icon').first().simulate('click');
+    });
+
+    it('should open the modal and clear cached services if the Clear Cached Configuration button is clicked', () => {
+      localStorage.setItem('PERSISTED_patientId', 'patient-123');
+      expect(localStorage.getItem('PERSISTED_patientId')).toEqual('patient-123');
+      shallowedComponent.find('Menu').childAt(7).simulate('click');
+      expect(shallowedComponent.state('settingsOpen')).toBeFalsy();
+      expect(localStorage.getItem('PERSISTED_patientId')).toEqual(null);
     });
   });
 });


### PR DESCRIPTION
To make it easier for users to clear their Sandbox configuration that is cached in localStorage, we should add a button to the header settings menu called "Clear Cached Configuration". This should clear their cached FHIR server, patient ID, CDS Services, and hook/view. On the next refresh of the page, the Sandbox should load with all default configured values. 