### PR TITLE
Add sub field into JWT payload body. Fixes #33

### DIFF
--- a/src/retrieve-data-helpers/jwt-generator.js
+++ b/src/retrieve-data-helpers/jwt-generator.js
@@ -1,4 +1,5 @@
 import privKey from '../../keys/ecprivkey.pem';
+import { productionClientId } from '../config/fhir-config';
 
 const JWT = require('jsrsasign');
 const uuid = require('uuid/v4');
@@ -6,6 +7,7 @@ const uuid = require('uuid/v4');
 function generateJWT(audience) {
   const jwtPayload = JSON.stringify({
     iss: 'https://sandbox.cds-hooks.org',
+    sub: productionClientId,
     aud: audience,
     exp: Math.round((Date.now() / 1000) + 300),
     iat: Math.round((Date.now() / 1000)),

--- a/tests/retrieve-data-helpers/jwt-generator.test.js
+++ b/tests/retrieve-data-helpers/jwt-generator.test.js
@@ -1,3 +1,5 @@
+import { productionClientId } from '../../src/config/fhir-config';
+
 describe('JWT Generator', () => {
   let generateJWT;
   let signedJwtMock = '1234';
@@ -22,6 +24,7 @@ describe('JWT Generator', () => {
     const audience = 'http://example-services.com/cds-services/1';
     const expectedPayload = JSON.stringify({
       iss: `https://sandbox.cds-hooks.org`,
+      sub: productionClientId,
       aud: audience,
       exp: Math.round((Date.now() / 1000) + 300),
       iat: Math.round((Date.now() / 1000)),


### PR DESCRIPTION
Adding the `sub` field as required in the CDS Hooks spec to the JWT payload.