### PR TITLE
Switch to production client ID for launching Sandbox securely

### DIFF
--- a/src/retrieve-data-helpers/smart-authorize.js
+++ b/src/retrieve-data-helpers/smart-authorize.js
@@ -1,4 +1,4 @@
-import { localhostClientId as clientId, allScopes } from '../config/fhir-config';
+import { productionClientId as clientId, allScopes } from '../config/fhir-config';
 
 FHIR.oauth2.authorize({
   client_id: clientId,


### PR DESCRIPTION
Switching to use the production client ID for launching the Sandbox securely against HSPC. 