### PR TITLE
Switch JWK endpoint to new well-known site URL

### DIFF
--- a/src/retrieve-data-helpers/jwt-generator.js
+++ b/src/retrieve-data-helpers/jwt-generator.js
@@ -18,7 +18,7 @@ function generateJWT(audience) {
     alg: 'ES256',
     typ: 'JWT',
     kid: 'd9cd3c4f-eb08-4304-b973-44f352fd2ca2',
-    jku: 'https://raw.githubusercontent.com/cds-hooks/sandbox/master/keys/jwk-keypair.json',
+    jku: 'https://sandbox.cds-hooks.org/.well-known/jwks.json',
   });
 
   return JWT.jws.JWS.sign(null, jwtHeader, jwtPayload, privKey);

--- a/tests/retrieve-data-helpers/jwt-generator.test.js
+++ b/tests/retrieve-data-helpers/jwt-generator.test.js
@@ -35,7 +35,7 @@ describe('JWT Generator', () => {
       alg: 'ES256',
       typ: 'JWT',
       kid: 'd9cd3c4f-eb08-4304-b973-44f352fd2ca2',
-      jku: 'https://raw.githubusercontent.com/cds-hooks/sandbox/master/keys/jwk-keypair.json'
+      jku: 'https://sandbox.cds-hooks.org/.well-known/jwks.json'
     });
     expect(generateJWT(audience)).toEqual(signedJwtMock);
     expect(signMethodMock).toHaveBeenCalledWith(null, expectedHeader, expectedPayload, mockPrivateKey);


### PR DESCRIPTION
Switching to our `.well-known/jwks.json` endpoint (https) instead of the master branch raw file.