### PR TITLE
Check for prefetch emptiness before trying to process prefetch business before service call

### DIFF
--- a/src/retrieve-data-helpers/service-exchange.js
+++ b/src/retrieve-data-helpers/service-exchange.js
@@ -136,7 +136,7 @@ function callServices(url, context) {
 
   const serviceDefinition = state.cdsServicesState.configuredServices[url];
 
-  if (serviceDefinition.prefetch) {
+  if (serviceDefinition.prefetch && Object.keys(serviceDefinition.prefetch).length) {
     const fulFilled = prefetchDataPromises(fhirServer, serviceDefinition.prefetch);
     return fulFilled.then((prefetch) => {
       if (prefetch && Object.keys(prefetch).length) {

--- a/tests/retrieve-data-helpers/service-exchange.test.js
+++ b/tests/retrieve-data-helpers/service-exchange.test.js
@@ -20,6 +20,7 @@ describe('Service Exchange', () => {
   let mockServiceWithPrefetchEncoded;
   let mockServiceNoEncoding;
   let mockServiceWithoutPrefetch;
+  let mockServiceWithEmptyPrefetch;
   let mockHookInstance;
   let mockRequest;
   let mockRequestWithContext;
@@ -115,6 +116,9 @@ describe('Service Exchange', () => {
               test: 'Patient/{{context.patientId}}'
             }
           },
+          [`${mockServiceWithEmptyPrefetch}`]: {
+            prefetch: {},
+          },
           [`${mockServiceWithoutPrefetch}`]: {}
         }
       }
@@ -199,6 +203,14 @@ describe('Service Exchange', () => {
       mockAxios.onPost(mockServiceWithoutPrefetch).reply(serviceResultStatus, mockServiceResult);
       return callServices(mockServiceWithoutPrefetch).then(() => {
         expect(spy).toHaveBeenCalledWith(mockServiceWithoutPrefetch, mockRequest, mockServiceResult, serviceResultStatus);
+      });
+    });
+
+    it('resolves and dispatches data from a successful CDS Service call with empty an prefetch object', () => {
+      const serviceResultStatus = 200;
+      mockAxios.onPost(mockServiceWithEmptyPrefetch).reply(serviceResultStatus, mockServiceResult);
+      return callServices(mockServiceWithEmptyPrefetch).then(() => {
+        expect(spy).toHaveBeenCalledWith(mockServiceWithEmptyPrefetch, mockRequest, mockServiceResult, serviceResultStatus);
       });
     });
 


### PR DESCRIPTION
Recently came across a CDS Service that contained an empty prefetch body in their service definition. The service exchange got stuck at the prefetch phase when a Promise was not resolved due to not processing any prefetch keys. We should flex the Sandbox to also check for empty prefetch bodies.