### PR TITLE
Re-invoke services on current view tab being clicked again if context is applicable. Fixes #44 and #42

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -513,17 +513,6 @@
         "trim-right": "1.0.1"
       }
     },
-    "babel-helper-builder-binary-assignment-operator-visitor": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
-      "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-      "dev": true,
-      "requires": {
-        "babel-helper-explode-assignable-expression": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
     "babel-helper-builder-react-jsx": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
@@ -557,17 +546,6 @@
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
         "lodash": "4.17.5"
-      }
-    },
-    "babel-helper-explode-assignable-expression": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
-      "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
       }
     },
     "babel-helper-function-name": {
@@ -723,12 +701,6 @@
       "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
       "dev": true
     },
-    "babel-plugin-syntax-exponentiation-operator": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=",
-      "dev": true
-    },
     "babel-plugin-syntax-flow": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
@@ -745,12 +717,6 @@
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
-      "dev": true
-    },
-    "babel-plugin-syntax-trailing-function-commas": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=",
       "dev": true
     },
     "babel-plugin-transform-async-to-generator": {
@@ -998,17 +964,6 @@
         "regexpu-core": "2.0.0"
       }
     },
-    "babel-plugin-transform-exponentiation-operator": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
-      "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-      "dev": true,
-      "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-        "babel-runtime": "6.26.0"
-      }
-    },
     "babel-plugin-transform-flow-strip-types": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
@@ -1104,56 +1059,6 @@
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
           "dev": true
-        }
-      }
-    },
-    "babel-preset-env": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
-      "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
-      "dev": true,
-      "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-async-to-generator": "6.24.1",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.26.0",
-        "browserslist": "2.11.3",
-        "invariant": "2.2.2",
-        "semver": "5.5.0"
-      },
-      "dependencies": {
-        "browserslist": {
-          "version": "2.11.3",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.11.3.tgz",
-          "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
-          "dev": true,
-          "requires": {
-            "caniuse-lite": "1.0.30000810",
-            "electron-to-chromium": "1.3.34"
-          }
         }
       }
     },

--- a/src/components/ContextView/context-view.jsx
+++ b/src/components/ContextView/context-view.jsx
@@ -96,7 +96,7 @@ const mapStateToProps = (store) => {
   function getFirstServiceForHook(services) {
     const serviceKeys = Object.keys(services);
     if (serviceKeys.length) {
-      return services[serviceKeys[0]];
+      return serviceKeys[0];
     }
     return null;
   }

--- a/src/reducers/service-exchange-reducers.js
+++ b/src/reducers/service-exchange-reducers.js
@@ -17,7 +17,7 @@ const serviceExchangeReducers = (state = initialState, action) => {
           service.responseStatus = action.responseStatus;
           const exchanges = Object.assign({}, state.exchanges);
           exchanges[action.url] = service;
-          return Object.assign({}, state, { selectedService: state.selectedService || action.url, exchanges });
+          return Object.assign({}, state, { exchanges });
         }
         break;
       }

--- a/tests/components/ContextView/context-view.test.js
+++ b/tests/components/ContextView/context-view.test.js
@@ -69,7 +69,7 @@ describe('ServiceContextView component', () => {
   it('matches props passed down from Redux decorator', () => {
     const serviceKeys = Object.keys(filteredServices);
     expect(pureComponent.prop('services')).toEqual(filteredServices);
-    expect(pureComponent.prop('initialService')).toEqual(filteredServices[serviceKeys[0]]);
+    expect(pureComponent.prop('initialService')).toEqual(serviceKeys[0]);
     expect(pureComponent.prop('isContextVisible')).toEqual(storeState.hookState.isContextVisible);
     expect(pureComponent.prop('selectedService')).toEqual(storeState.serviceExchangeState.selectedService);
     expect(pureComponent.prop('exchanges')).toEqual(storeState.serviceExchangeState.exchanges);
@@ -123,7 +123,7 @@ describe('ServiceContextView component', () => {
     });
 
     it('ensures the panel text contains an appropriate message if service exchange has not been stored', () => {
-      storeState.serviceExchangeState.selectedService = '';
+      storeState.serviceExchangeState.selectedService = 'http://xyz-123.com/cds-services/id-1';
       mockStore = mockStoreWrapper(storeState);
       let component = <ConnectedView store={mockStore}/>;
       wrapper = mount(component);

--- a/tests/reducers/service-exchange-reducers.test.js
+++ b/tests/reducers/service-exchange-reducers.test.js
@@ -28,7 +28,7 @@ describe('Services Exchange Reducers', () => {
       expect(reducer(state, action)).toEqual(state);
     });
 
-    it('should store the request/response of an exchange and set selectedService if not set already', () => {
+    it('should store the request/response of an exchange', () => {
       const action = Object.assign({
         type: types.STORE_SERVICE_EXCHANGE,
         url: url
@@ -36,27 +36,8 @@ describe('Services Exchange Reducers', () => {
 
 
       const newState = Object.assign({}, state, {
-        selectedService: url,
         exchanges: {
           [action.url]: storedExchange
-        }
-      });
-      expect(reducer(state, action)).toEqual(newState);
-    });
-
-    it('should store the request/response of an exchange but keep the selectedService if already set', () => {
-      state.selectedService = url;
-      const extraUrl = 'http://some-other-url.com/cds-services/1';
-      const action = Object.assign({
-        type: types.STORE_SERVICE_EXCHANGE,
-        url: extraUrl,
-      }, storedExchange);
-
-
-      const newState = Object.assign({}, state, {
-        selectedService: url,
-        exchanges: {
-          [extraUrl]: storedExchange
         }
       });
       expect(reducer(state, action)).toEqual(newState);


### PR DESCRIPTION
Currently, if the user's current view tab is clicked again on the Header, the CDS Developer Panel req/res will display that no exchange was made with the associated selected CDS Service from the dropdown. Additionally, it would make sense for testers who are updating their services to be able to re-trigger their configured services by just clicking the current view's tab again. This would not invoke their discovery endpoint, as the services are already stored by the Sandbox, but rather just do another service exchange (unless if on `medication-prescribe`, a medication has not been selected yet). This would save users from having to refresh their page, re-configure their services endpoint, and/or switch to the other view and then back.

We can fix these two issues by not setting the dropdown CDS Service to the service that is being requested by the Sandbox, as well as just calling the services for the user's current view instead of setting a new `hook` in the application state.