### PR TITLE
Persist configured CDS Services on smart-launched Sandbox instances. Fixes #41

### DIFF
--- a/src/reducers/cds-services-reducers.js
+++ b/src/reducers/cds-services-reducers.js
@@ -65,7 +65,7 @@ const cdsServicesReducers = (state = initialState, action) => {
               // http(s) protocol in the access token
               if ((accessToken && accessToken.serviceDiscoveryURL &&
                 accessToken.serviceDiscoveryURL.replace(/^https?:\/\//i, '') !== action.discoveryUrl.replace(/^https?:\/\//i, ''))
-                || !accessToken) {
+                || (accessToken && !accessToken.serviceDiscoveryURL) || !accessToken) {
                 const concatArr = newConfiguredServiceUrls.concat([action.discoveryUrl]);
                 newConfiguredServiceUrls = uniq(concatArr);
               }

--- a/tests/reducers/cds-services-reducers.test.js
+++ b/tests/reducers/cds-services-reducers.test.js
@@ -1,25 +1,48 @@
-import reducer from '../../src/reducers/cds-services-reducers';
+import configureStore from 'redux-mock-store';
 import * as types from '../../src/actions/action-types';
 
 describe('CDS Services Reducer', () => {
   let state = {};
   let persistedService = 'http://stored-service.com/cds-services';
+  let reducer;
+  let mockStore;
+  let storeState;
+  let mockStoreWrapper = configureStore([]);
+
+  function setup(store) {
+    mockStore = mockStoreWrapper(store);
+    jest.setMock('../../src/store/store', mockStore);
+    reducer = require('../../src/reducers/cds-services-reducers').default;
+  }
 
   beforeEach(() => {
-    localStorage.setItem('PERSISTED_cdsServices', JSON.stringify([persistedService]));
+    storeState = {
+      fhirServerState: {
+        accessToken: null,
+      },
+    };
     state = {
       configuredServices: {},
-      configuredServiceUrls: [persistedService],
+      configuredServiceUrls: [],
       defaultUrl: 'https://fhir-org-cds-services.appspot.com/cds-services',
       testServicesUrl: null,
     };
   });
 
+  afterEach(() => {
+    jest.resetModules();
+  });
+
   it('should return the initial state without action', () => {
+    setup(storeState);
     expect(reducer(undefined, {})).toEqual(Object.assign({}, state, { configuredServiceUrls: [] }));
   });
 
   describe('DISCOVER_CDS_SERVICES', () => {
+    beforeEach(() => {
+      setup(storeState);
+    });
+
     it('should return the state if action does not qualify state change', () => {
       const action = { type: types.DISCOVER_CDS_SERVICES };
       expect(reducer(state, action)).toEqual(state);
@@ -37,12 +60,19 @@ describe('CDS Services Reducer', () => {
   });
 
   describe('DISCOVER_CDS_SERVICES_SUCCESS', () => {
+    beforeEach(() => {
+      localStorage.setItem('PERSISTED_cdsServices', JSON.stringify([persistedService]));
+      state.configuredServiceUrls = [persistedService];
+    });
+
     it('should return the state if action does not qualify state change', () => {
+      setup(storeState);
       const action = { type: types.DISCOVER_CDS_SERVICES_SUCCESS };
       expect(reducer(state, action)).toEqual(state);
     });
 
     it('should return the state if services do not need to be re-configured', () => {
+      setup(storeState);
       const exampleUrl = 'http://example.com/cds-services';
       const service = {
         enabled: true,
@@ -65,6 +95,7 @@ describe('CDS Services Reducer', () => {
     });
 
     it('should handle the DISCOVER_CDS_SERVICES_SUCCESS action accordingly', () => {
+      setup(storeState);
       const exampleUrl = 'http://example.com/cds-services';
       state = Object.assign({}, state, { testServicesUrl: exampleUrl });
       const service = {
@@ -87,9 +118,69 @@ describe('CDS Services Reducer', () => {
       expect(reducer(state, action)).toEqual(newState);
       expect(localStorage.getItem('PERSISTED_cdsServices')).toEqual(JSON.stringify([persistedService, exampleUrl]));
     });
+
+    it('should persist successful service connections if the app has an access_token and no serviceDiscoveryURL token property', () => {
+      storeState.fhirServerState.accessToken = {
+        access_token: 'foo-bar',
+      };
+      setup(storeState);
+      const exampleUrl = 'http://example.com/cds-services';
+      state = Object.assign({}, state, { testServicesUrl: exampleUrl });
+      const service = {
+        enabled: true,
+        id: 'example-service',
+        url: `${exampleUrl}/example-service`
+      };
+      const action = {
+        type: types.DISCOVER_CDS_SERVICES_SUCCESS,
+        services: [service],
+        discoveryUrl: exampleUrl,
+      };
+      const configuredServices = {};
+      configuredServices[`${service.url}`] = service;
+      const newState = Object.assign({}, state, {
+        configuredServices: configuredServices,
+        configuredServiceUrls: [persistedService, exampleUrl],
+        testServicesUrl: null,
+      });
+      expect(reducer(state, action)).toEqual(newState);
+      expect(localStorage.getItem('PERSISTED_cdsServices')).toEqual(JSON.stringify([persistedService, exampleUrl]));
+    });
+
+    it('should not persist successful service connections from services from the accessToken serviceDiscoveryURL property', () => {
+      const exampleUrl = 'http://example.com/cds-services';
+      storeState.fhirServerState.accessToken = {
+        serviceDiscoveryURL: exampleUrl,
+      };
+      setup(storeState);
+      state = Object.assign({}, state, { testServicesUrl: exampleUrl });
+      const service = {
+        enabled: true,
+        id: 'example-service',
+        url: `${exampleUrl}/example-service`
+      };
+      const action = {
+        type: types.DISCOVER_CDS_SERVICES_SUCCESS,
+        services: [service],
+        discoveryUrl: exampleUrl,
+      };
+      const configuredServices = {};
+      configuredServices[`${service.url}`] = service;
+      const newState = Object.assign({}, state, {
+        configuredServices: configuredServices,
+        configuredServiceUrls: [persistedService],
+        testServicesUrl: null,
+      });
+      expect(reducer(state, action)).toEqual(newState);
+      expect(localStorage.getItem('PERSISTED_cdsServices')).toEqual(JSON.stringify([persistedService]));
+    });
   });
 
   describe('RESET_SERVICES', () => {
+    beforeEach(() => {
+      setup(storeState);
+    });
+
     it('removes all configured services from the app', () => {
       state.configuredServices['http://example.com'] = { enabled: true };
       const stateCopy = JSON.parse(JSON.stringify(state));
@@ -104,6 +195,10 @@ describe('CDS Services Reducer', () => {
   });
 
   describe('TOGGLE_SERVICE', () => {
+    beforeEach(() => {
+      setup(storeState);
+    });
+
     it('toggles the enabled status for a CDS Service if it exists', () => {
       const service = 'http://example.com';
       state.configuredServices[service] = { enabled: true };
@@ -131,6 +226,10 @@ describe('CDS Services Reducer', () => {
   });
 
   describe('DELETE_SERVICE', () => {
+    beforeEach(() => {
+      setup(storeState);
+    });
+
     it('removes a CDS Service from app config if it exists', () => {
       const service = 'http://example.com';
       state.configuredServices[service] = { enabled: true };
@@ -156,6 +255,10 @@ describe('CDS Services Reducer', () => {
   });
 
   describe('Pass-through Actions', () => {
+    beforeEach(() => {
+      setup(storeState);
+    });
+
     it('should return state if an action should pass through this reducer without change to state', () => {
       const action = { type: 'SOME_OTHER_ACTION' };
       expect(reducer(state, action)).toEqual(state);


### PR DESCRIPTION
Currently, the Sandbox has the ability to save configured CDS Services from the user, so that they can refresh the page and still have their services configured. This functionality should exist whether the Sandbox is launched openly or done through a smart-launch, but the latter is not taking place currently. This is due to filtering out the `serviceDiscoveryURL` service from the accessToken from the persisted services list (as this will already be invoked automatically), and assuming access tokens contain this property. 

We should add logic to still configure successfully connected services in smart-launched sandboxes, even if it does not have a `serviceDiscoveryURL` token parameter.