### PR TITLE
Flex the current user if a userId property is found in SMART auth response from a smart-launched Sandbox. Fixes #51

### DIFF
--- a/src/reducers/patient-reducers.js
+++ b/src/reducers/patient-reducers.js
@@ -2,7 +2,8 @@ import * as types from '../actions/action-types';
 
 const initialState = {
   defaultPatientId: 'SMART-1288992',
-  defaultUserId: 'Practitioner/COREPRACTITIONER1',
+  defaultUser: 'Practitioner/COREPRACTITIONER1',
+  currentUser: '',
   currentPatient: {
     id: 'SMART-1288992',
     name: 'Daniel X. Adams',
@@ -53,6 +54,15 @@ const patientReducers = (state = initialState, action) => {
         newPatient.conditionsResources = filteredEntries;
         return Object.assign({}, state, { currentPatient: newPatient });
       }
+
+      case types.SMART_AUTH_SUCCESS: {
+        const { authResponse } = action;
+        if (authResponse && authResponse.userId) {
+          return Object.assign({}, state, { currentUser: authResponse.userId });
+        }
+        return state;
+      }
+
       default: {
         return state;
       }

--- a/src/retrieve-data-helpers/service-exchange.js
+++ b/src/retrieve-data-helpers/service-exchange.js
@@ -34,7 +34,7 @@ function encodeUriParameters(template) {
 function completePrefetchTemplate(prefetch) {
   const state = store.getState();
   const patient = state.patientState.currentPatient.id;
-  const user = state.patientState.defaultUserId;
+  const user = state.patientState.currentUser || state.patientState.defaultUser;
   const prefetchRequests = Object.assign({}, prefetch);
   Object.keys(prefetchRequests).forEach((prefetchKey) => {
     let prefetchTemplate = prefetchRequests[prefetchKey];
@@ -95,7 +95,7 @@ function callServices(url, context) {
   const state = store.getState();
   const hook = state.hookState.currentHook;
   const fhirServer = state.fhirServerState.currentFhirServer;
-  const user = state.patientState.defaultUserId;
+  const user = state.patientState.currentUser || state.patientState.defaultUser;
 
   const patient = state.patientState.currentPatient.id;
   const activityContext = {};

--- a/tests/reducers/patient-reducers.test.js
+++ b/tests/reducers/patient-reducers.test.js
@@ -7,7 +7,8 @@ describe('Patient Reducers', () => {
   beforeEach(() => {
     state = {
       defaultPatientId: 'SMART-1288992',
-      defaultUserId: 'Practitioner/COREPRACTITIONER1',
+      defaultUser: 'Practitioner/COREPRACTITIONER1',
+      currentUser: '',
       currentPatient: {
         id: 'SMART-1288992',
         name: 'Daniel X. Adams',
@@ -82,6 +83,38 @@ describe('Patient Reducers', () => {
       });
 
       expect(reducer(state, action)).toEqual(newState);
+    });
+  });
+
+  describe('SMART_AUTH_SUCCESS', () => {
+    it('updates the current user if a user is supplied in the SMART auth response', () => {
+      const authResponseMock = {
+        userId: 'Practitioner/some-user',
+      };
+      const metadataMock = { fhirVersion: '1.0.2' };
+      const action = {
+        type: types.SMART_AUTH_SUCCESS,
+        authResponse: authResponseMock,
+        metadata: metadataMock,
+      };
+
+      const newState = Object.assign({}, state, {
+        currentUser: authResponseMock.userId,
+      });
+
+      expect(reducer(state, action)).toEqual(newState);
+    });
+
+    it('returns state if a user is not supplied in the SMART auth response', () => {
+      const authResponseMock = {};
+      const metadataMock = { fhirVersion: '1.0.2' };
+      const action = {
+        type: types.SMART_AUTH_SUCCESS,
+        authResponse: authResponseMock,
+        metadata: metadataMock,
+      };
+
+      expect(reducer(state, action)).toEqual(state);
     });
   });
 

--- a/tests/retrieve-data-helpers/service-exchange.test.js
+++ b/tests/retrieve-data-helpers/service-exchange.test.js
@@ -64,7 +64,7 @@ describe('Service Exchange', () => {
       hookInstance: mockHookInstance,
       hook: 'patient-view',
       fhirServer: mockFhirServer,
-      user: 'Practitioner/example',
+      user: 'Practitioner/specified-1',
       patient: mockPatient,
       context: { patientId: mockPatient }
     };
@@ -89,7 +89,8 @@ describe('Service Exchange', () => {
     defaultStore = {
       hookState: { currentHook: 'patient-view' },
       patientState: {
-        defaultUserId: 'Practitioner/example',
+        defaultUser: 'Practitioner/default',
+        currentUser: 'Practitioner/specified-1',
         currentPatient: {
           id: mockPatient
         }
@@ -199,6 +200,16 @@ describe('Service Exchange', () => {
     });
 
     it('resolves and dispatches data from a successful CDS service call', () => {
+      const serviceResultStatus = 200;
+      mockAxios.onPost(mockServiceWithoutPrefetch).reply(serviceResultStatus, mockServiceResult);
+      return callServices(mockServiceWithoutPrefetch).then(() => {
+        expect(spy).toHaveBeenCalledWith(mockServiceWithoutPrefetch, mockRequest, mockServiceResult, serviceResultStatus);
+      });
+    });
+
+    it('resolves and dispatches data from a successful CDS Service call with default user', () => {
+      defaultStore.patientState.currentUser = '';
+      mockRequest.user = 'Practitioner/default';
       const serviceResultStatus = 200;
       mockAxios.onPost(mockServiceWithoutPrefetch).reply(serviceResultStatus, mockServiceResult);
       return callServices(mockServiceWithoutPrefetch).then(() => {


### PR DESCRIPTION
Currently, the `user` property of the Sandbox indicating the provider is defaulted at the practitioner from the default HSPC FHIR server, `Practitioner/COREPRACTITIONER1`. If a user launches the Sandbox from their own HSPC FHIR Server, the Sandbox should be able to take the `userId` property out of the SMART auth response and use that as the `user` property in the Sandbox for service requests. 