### PR TITLE
Change JWKS use to indicate key is used for signing.

### DIFF
--- a/build/.well-known/jwks.json
+++ b/build/.well-known/jwks.json
@@ -2,7 +2,7 @@
   "keys": [
     {
       "kty": "EC",
-      "use": "enc",
+      "use": "sig",
       "crv": "P-256",
       "kid": "d9cd3c4f-eb08-4304-b973-44f352fd2ca2",
       "x": "QWI9fI8TcNtdikhVs_M1N_Szb7BOj19etvIKfrQMa9k",

--- a/keys/jwk-keypair.json
+++ b/keys/jwk-keypair.json
@@ -3,7 +3,7 @@
     {
       "kty": "EC",
       "d": "_DM2VJ_ZJSF6bIZD6KuqWX1uxn6VGQkIoEJVk7kP4A4",
-      "use": "enc",
+      "use": "sig",
       "crv": "P-256",
       "kid": "d9cd3c4f-eb08-4304-b973-44f352fd2ca2",
       "x": "QWI9fI8TcNtdikhVs_M1N_Szb7BOj19etvIKfrQMa9k",


### PR DESCRIPTION
Changed key use field in JWKS to indicate that the key is used for signing. This is needed by many libraries for retrieving the signing key from the JWKS so that the token signature can be verified.