### PR TITLE
Update Rx View to invoke order-select hook (Fixes #74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The Sandbox can act as a demo tool to simulate CDS Hooks and visualize the workf
 The Sandbox supports the following CDS Hooks Workflows:
 
 - `patient-view`: On initial load, the Sandbox displays what looks like the opening of a patient's chart. A default CDS Service displays a card pertaining to the `patient-view` hook invoked on this view. On the toolbar in the header, the Patient View tab should be highlighted to indicate this default view. When navigated to this view, the Sandbox will invoke configured CDS Services listening on the `patient-view` hook.
-- `medication-prescribe`: Invoked by the Rx View tab on the header, the Sandbox displays an EHR-like view of a form a care provider would use to author a medication for a specific condition. With the patient in context, you can drill down into the specific (if any) conditions the patient has. Additionally, you can choose from an extensive list of medications to prescribe, and adjust dosage instructions accordingly. Any action taken on this view once a medication is prescribed will invoke the configured CDS Services on this tool listening on the `medication-prescribe` hook.
+- `order-select`: Invoked by the Rx View tab on the header, the Sandbox displays an EHR-like view of a form a care provider would use to author a medication for a specific condition. With the patient in context, you can drill down into the specific (if any) conditions the patient has. Additionally, you can choose from an extensive list of medications to prescribe, and adjust dosage instructions accordingly. Any action taken on this view once a medication is prescribed will invoke the configured CDS Services on this tool listening on the `order-select` hook.
    
 ### Tools
 
@@ -40,7 +40,7 @@ The tool also allows for testing against different patients and FHIR servers (se
 While users have the option to configure properties of the Sandbox in-app like the FHIR server, the patient in context, the medication details on Rx View, etc., they also have the option to configure these values on launch via URL query parameters. The Sandbox supports the following query parameters.
   - `fhirServiceUrl` - FHIR server base URL that MUST be URL encoded (i.e. `fhirServiceUrl=https%3A%2F%2Fapi.hspconsortium.org%2Fcdshooksdstu2%2Fopen`)
   - `patientId` - The ID of the Patient in context as it relates to the associated FHIR server (i.e. `patientId=SMART-1288992`)
-  - `hook` - The view/associated hook of the Sandbox (i.e. `hook=medication-prescribe`)
+  - `hook` - The view/associated hook of the Sandbox (i.e. `hook=order-select`)
   - `serviceDiscoveryURL` - A comma-separated list of URL encoded CDS service discovery endpoints (i.e. `serviceDiscoveryURL=http%3A%2F%2Flocalhost%3A3000%2Fcds-services,https%3A%2F%2Ffhir-org-cds-services.appspot.com%2Fcds-services`)
   - `prescribedMedication` - Coding code of a medication from the system, `http://www.nlm.nih.gov/research/umls/rxnorm` (i.e. `prescribedMedication=731370`)
   - `prescribedInstructionNumber` - Dosage number of medication to take (i.e. `prescribedInstructionNumber=2`)
@@ -51,7 +51,7 @@ While users have the option to configure properties of the Sandbox in-app like t
 
 Now, users can construct a link that has their preferred properties configured on launch instead of manually inputting them in-app, and can use the link every time to launch their configured Sandbox (does not include SMART-launched Sandbox method). See below for an example URL.
 
-> https://sandbox.cds-hooks.org/?hook=medication-prescribe&prescribedMedication=731370&prescribedReason=1201005&prescribedInstructionNumber=2&prescribedInstructionFrequency=daily
+> https://sandbox.cds-hooks.org/?hook=order-select&prescribedMedication=731370&prescribedReason=1201005&prescribedInstructionNumber=2&prescribedInstructionFrequency=daily
 
 
 ## Testing w/ Secured FHIR Servers

--- a/src/components/Header/header.jsx
+++ b/src/components/Header/header.jsx
@@ -41,7 +41,7 @@ const propTypes = {
    */
   hook: PropTypes.string.isRequired,
   /**
-   * Function to set a hook in the store (i.e. 'patient-view' to 'medication-prescribe')
+   * Function to set a hook in the store (i.e. 'patient-view' to 'order-select')
    */
   setHook: PropTypes.func.isRequired,
   /**
@@ -64,7 +64,7 @@ const propTypes = {
 
 /**
  * This component represents the Header for the application, which encompasses the title, logo, and several configuration options. The header allows the user
- * to select between different hook views (i.e. patient-view and medication-prescribe), and presents options to change the FHIR server and/or the patient in 
+ * to select between different hook views (i.e. patient-view and order-select), and presents options to change the FHIR server and/or the patient in 
  * context, add CDS services, among other options.
  */
 export class Header extends Component {
@@ -134,7 +134,7 @@ export class Header extends Component {
 
   /**
    * Once a new tab (hook) is chosen, the Sandbox must grab the applicable services for that hook and invoke them.
-   * In a special consideration for the Rx View (medication-prescribe), we see if a medication has already been chosen
+   * In a special consideration for the Rx View (order-select), we see if a medication has already been chosen
    * from a previous selection, and if so, call the services immediately with that previously chosen medication in context
    */
   switchHook(hook) {
@@ -150,7 +150,7 @@ export class Header extends Component {
           // If the tab is clicked again, make sure the Sandbox is qualified to call out to EHR's based
           // on current context (i.e. for the Rx View, ensure a medication has been prescribed before
           // re-invoking the services on that hook if the Rx View tab is clicked multiple times)
-          if (hook === 'medication-prescribe') {
+          if (hook === 'order-select') {
             const medicationPrescribed = state.medicationState.decisions.prescribable &&
               state.medicationState.medListPhase === 'done';
             if (medicationPrescribed) {
@@ -272,7 +272,7 @@ export class Header extends Component {
       <div className={styles['nav-tabs']}>
         <div className={styles['nav-container']}>
           <button className={this.getNavClasses('patient-view')} onClick={() => this.switchHook('patient-view')}>Patient View</button>
-          <button className={this.getNavClasses('medication-prescribe')} onClick={() => this.switchHook('medication-prescribe')}>Rx View</button>
+          <button className={this.getNavClasses('order-select')} onClick={() => this.switchHook('order-select')}>Rx View</button>
         </div>
       </div>);
 

--- a/src/components/MainView/main-view.jsx
+++ b/src/components/MainView/main-view.jsx
@@ -110,7 +110,7 @@ export class MainView extends Component {
   async componentDidMount() {
     // Set the loading spinner face-up
     this.props.setLoadingStatus(true);
-    const validHooks = ['patient-view', 'medication-prescribe'];
+    const validHooks = ['patient-view', 'order-select'];
     let parsedHook = this.getQueryParam('hook');
     if (validHooks.indexOf(parsedHook) < 0) {
       parsedHook = null;

--- a/src/components/RxView/rx-view.jsx
+++ b/src/components/RxView/rx-view.jsx
@@ -102,7 +102,7 @@ const propTypes = {
 };
 
 /**
- * Left-hand side on the mock-EHR view that displays the cards and relevant UI for the medication-prescribe hook.
+ * Left-hand side on the mock-EHR view that displays the cards and relevant UI for the order-select hook.
  * The services are not called until a medication is chosen, or a change in prescription is made
  */
 export class RxView extends Component {
@@ -269,14 +269,23 @@ export class RxView extends Component {
    */
   executeRequests() {
     if (Object.keys(this.props.services).length) {
+
+      const resource = this.props.medicationOrder;
+      const selection = resource.resourceType + '/' + resource.id;
+
       // For each service, call service for request/response exchange
       forIn(this.props.services, (val, key) => {
-        const context = [{
-          key: 'medications',
+        const context = [
+          {
+            key: 'selections',
+            value: [selection]
+          },
+          {
+          key: 'draftOrders',
           value: {
             resourceType: 'Bundle',
             entry: [{
-              resource: this.props.medicationOrder,
+              resource: resource,
             }],
           },
         }];
@@ -398,7 +407,7 @@ RxView.propTypes = propTypes;
 
 const mapStateToProps = (store) => {
   function isValidService(service) {
-    return service.hook === 'medication-prescribe' && service.enabled;
+    return service.hook === 'order-select' && service.enabled;
   }
 
   return {

--- a/src/reducers/medication-reducers.js
+++ b/src/reducers/medication-reducers.js
@@ -27,6 +27,7 @@ const createFhirResource = (fhirVersion, patientId, state) => {
   const isSTU3 = fhirVersion === '3.0.1';
   const resource = {
     resourceType: isSTU3 ? 'MedicationRequest' : 'MedicationOrder',
+    id: isSTU3 ? 'request-123' : 'order-123',
   };
   resource[`${isSTU3 ? 'authoredOn' : 'dateWritten'}`] = moment().format('YYYY-MM-DD');
   let startDate;

--- a/src/retrieve-data-helpers/patient-retrieval.js
+++ b/src/retrieve-data-helpers/patient-retrieval.js
@@ -6,7 +6,7 @@ import { signalSuccessPatientRetrieval, signalFailurePatientRetrieval } from '..
 /**
  * Retrieve Patient resource from the FHIR server in context with the patient id retrieved from the Redux store or access token (if applicable)
  * and dispatch successful or failed connection to the endpoint on the FHIR server. Additionally, grab Conditions data too, since a list of conditions
- * need to be displayed under the Rx View (medication-prescribe workflow).
+ * need to be displayed under the Rx View (order-select workflow).
  * @returns {Promise} - Promise to resolve elsewhere
  */
 function retrievePatient(testPatient) {

--- a/tests/actions/hook-actions.test.js
+++ b/tests/actions/hook-actions.test.js
@@ -3,7 +3,7 @@ import * as actions from '../../src/actions/hook-actions';
 
 describe('Hook Actions', () => {
   it('creates action to set a current hook for the application', () => {
-    const hook = 'medication-prescribe';
+    const hook = 'order-select';
     const expectedAction = {
       type: types.SET_HOOK,
       hook,

--- a/tests/components/ContextView/context-view.test.js
+++ b/tests/components/ContextView/context-view.test.js
@@ -36,7 +36,7 @@ describe('ServiceContextView component', () => {
             enabled: true,
           },
           [medServiceUrl]: {
-            hook: 'medication-prescribe',
+            hook: 'order-select',
             url: medServiceUrl,
             enabled: true,
           },

--- a/tests/components/Header/header.test.js
+++ b/tests/components/Header/header.test.js
@@ -57,7 +57,7 @@ describe('Header component', () => {
             enabled: true,
           },
           [`${mockMedService}`]: {
-            hook: 'medication-prescribe',
+            hook: 'order-select',
             enabled: true,
           },
         },
@@ -92,7 +92,7 @@ describe('Header component', () => {
     it('dispatches to switch hooks in app state if another view tab is clicked', () => {
       setup(storeState);
       shallowedComponent.childAt(0).dive().find('.nav-links').not('.active-link').simulate('click');
-      const medHookAction = { type: types.SET_HOOK, hook: 'medication-prescribe' };
+      const medHookAction = { type: types.SET_HOOK, hook: 'order-select' };
       expect(mockStore.getActions()).toEqual([medHookAction]);
     });
   
@@ -102,15 +102,15 @@ describe('Header component', () => {
       expect(mockExchange).toHaveBeenCalledWith(mockPatientService);
     });
   
-    it('does not call services on medication-prescribe if no medication is chosen yet', () => {
-      storeState.hookState.currentHook = 'medication-prescribe';
+    it('does not call services on order-select if no medication is chosen yet', () => {
+      storeState.hookState.currentHook = 'order-select';
       setup(storeState);
       shallowedComponent.childAt(0).dive().find('.active-link').simulate('click');
       expect(mockExchange).not.toHaveBeenCalled();
     });
 
-    it('does call services on medication-prescribe if a medication has been chosen', () => {
-      storeState.hookState.currentHook = 'medication-prescribe';
+    it('does call services on order-select if a medication has been chosen', () => {
+      storeState.hookState.currentHook = 'order-select';
       storeState.medicationState.decisions.prescribable = 'foo-medicine';
       storeState.medicationState.medListPhase = 'done';
       setup(storeState);

--- a/tests/components/MainView/main-view.test.js
+++ b/tests/components/MainView/main-view.test.js
@@ -127,10 +127,10 @@ describe('MainView component', () => {
 
   describe('Persisted State Values', () => {
     it('calls a function to set the hook status on state on mount from a persisted value on localStorage', () => {
-      localStorage.setItem('PERSISTED_hook', 'medication-prescribe');
+      localStorage.setItem('PERSISTED_hook', 'order-select');
       setup(storeState);
       const shallowedComponent = pureComponent.shallow();
-      expect(mockStore.getActions()[1]).toEqual(setHook('medication-prescribe'));
+      expect(mockStore.getActions()[1]).toEqual(setHook('order-select'));
     });
 
     it('calls a function to set the hook status on state on mount to patient-view if no persisted hook value present on localStorage', () => {
@@ -155,21 +155,21 @@ describe('MainView component', () => {
   describe('URL Parameter Values', () => {
     it('grabs the hook from the hook URL query parameter and sets it if its a known hook', async () => {
       jsdom.reconfigure({
-        url: 'http://example.com/?hook=medication-prescribe',
+        url: 'http://example.com/?hook=order-select',
       });
       setup(storeState);
       const shallowedComponent = await pureComponent.shallow();
-      expect(mockStore.getActions()[1]).toEqual(setHook('medication-prescribe'));
+      expect(mockStore.getActions()[1]).toEqual(setHook('order-select'));
     });
 
     it('sets stored local storage hook for unsupported hooks in the URL param', async () => {
-      localStorage.setItem('PERSISTED_hook', 'medication-prescribe');
+      localStorage.setItem('PERSISTED_hook', 'order-select');
       jsdom.reconfigure({
         url: 'http://example.com/?hook=abc-123',
       });
       setup(storeState);
       const shallowedComponent = await pureComponent.shallow();
-      expect(mockStore.getActions()[1]).toEqual(setHook('medication-prescribe'));
+      expect(mockStore.getActions()[1]).toEqual(setHook('order-select'));
     });
 
     it('calls the discovery endpoints of service discovery URLs in query parameters', async (done) => {

--- a/tests/components/RxView/rx-view.test.js
+++ b/tests/components/RxView/rx-view.test.js
@@ -48,7 +48,7 @@ describe('RxView component', () => {
       medications = [];
     }
     component = <RxView isContextVisible patient={patient} fhirServer={fhirServer} fhirVersion={'3.0.1'} 
-        services={services} hook={'medication-prescribe'} medListPhase={medListPhase} 
+        services={services} hook={'order-select'} medListPhase={medListPhase} 
         medications={medications} prescription={prescription} onMedicationChangeInput={onMedicationChangeInput} 
         chooseMedication={chooseMedication} chooseCondition={chooseCondition} updateDosageInstructions={updateDosageInstructions} 
         updateDate={updateDate} toggleEnabledDate={toggleEnabledDate} updateFhirResource={updateFhirResource}
@@ -79,7 +79,7 @@ describe('RxView component', () => {
       'http://example.com/cds-services/id-1': {
         url: 'http://example.com/cds-services/id-1',
         id: 'id-1',
-        hook: 'medication-prescribe',
+        hook: 'order-select',
         enabled: true,
       },
     };
@@ -102,7 +102,7 @@ describe('RxView component', () => {
       },
     };
     medListPhase = 'begin';
-    medicationOrder = { foo: 'foo' };
+    medicationOrder = { resourceType: 'MedicationRequest', id: '123' };
     mockSpy = jest.fn();
     chooseCondition = jest.fn();
     onMedicationChangeInput = jest.fn(); 
@@ -182,7 +182,13 @@ describe('RxView component', () => {
     Promise.resolve(newComponent).then(() => {
       expect(mockSpy).toHaveBeenCalledTimes(2);
       expect(mockSpy).toHaveBeenCalledWith('http://example.com/cds-services/id-1', [{
-        key: 'medications',
+        key: 'selections',
+        value: [
+          'MedicationRequest/123'
+        ],
+      },
+      {
+        key: 'draftOrders',
         value: {
           resourceType: 'Bundle',
           entry: [{

--- a/tests/middleware/persist-data.test.js
+++ b/tests/middleware/persist-data.test.js
@@ -115,16 +115,16 @@ describe('Persist Data Middleware', () => {
       const { next, invoke } = createMock();
       const action = {
         type: 'SET_HOOK',
-        hook: 'medication-prescribe',
+        hook: 'order-select',
       };
 
       invoke(action);
-      expect(localStorage.getItem('PERSISTED_hook')).toEqual('medication-prescribe');
+      expect(localStorage.getItem('PERSISTED_hook')).toEqual('order-select');
       expect(next).toHaveBeenCalledWith(action);
     });
 
     it('ignores setting localStorage for actions whose type is not SET_HOOK', () => {
-      const hook = 'medication-prescribe';
+      const hook = 'order-select';
       localStorage.setItem('PERSISTED_hook', hook);
       const { next, invoke } = createMock();
       const action = {

--- a/tests/reducers/hook-reducers.test.js
+++ b/tests/reducers/hook-reducers.test.js
@@ -44,7 +44,7 @@ describe('Hook Reducer', () => {
     it('should handle the SET_HOOK action accordingly', () => {
       const action = {
         type: types.SET_HOOK,
-        hook: 'medication-prescribe',
+        hook: 'order-select',
       };
 
       const newState = Object.assign({}, state, { currentHook: action.hook });

--- a/tests/reducers/medication-reducers.test.js
+++ b/tests/reducers/medication-reducers.test.js
@@ -174,6 +174,7 @@ describe('Medication Reducers', () => {
 
       const fhirResource = {
         resourceType: 'MedicationRequest',
+        id: 'request-123',
         authoredOn: moment().format('YYYY-MM-DD'),
         status: 'draft',
         subject: {

--- a/tests/retrieve-data-helpers/service-exchange.test.js
+++ b/tests/retrieve-data-helpers/service-exchange.test.js
@@ -71,7 +71,8 @@ describe('Service Exchange', () => {
     mockRequestWithContext = Object.assign({}, mockRequest, {
       context: {
         ...mockRequest.context,
-        medications: [{
+        selections: ['selection/id'],
+        draftOrders: [{
           foo: 'foo',
         }],
       },
@@ -245,7 +246,11 @@ describe('Service Exchange', () => {
       mockAxios.onPost(mockServiceWithoutPrefetch).reply(serviceResultStatus, mockServiceResult);
       const context = [
         {
-          key: 'medications',
+          key: 'selections',
+          value: ['selection/id'],
+        },
+        {
+          key: 'draftOrders',
           value: [{ foo: 'foo' }],
         },
       ];


### PR DESCRIPTION
https://github.com/cds-hooks/sandbox/issues/74

Other than find/replace changes, the following files were updated to account for the hook change:

* src/components/RxView/rx-view.jsx - update hook context from 'medications' to 'selections' and 'draftOrders'
* src/reducers/medication-reducers.js - assign an order id that can be referenced by 'selections' context

Also outstanding: By default, the sandbox discovers HSPC's https://fhir-org-cds-services.appspot.com/cds-services/cms-price-check service listening for the medication-prescribe hook.  Logged https://healthservices.atlassian.net/browse/SNDBX-1170 to get an order-select version

cc: @kolkheang