### PR TITLE
Call Feedback service when a suggestion is accepted

### DIFF
--- a/src/components/CardList/card-list.jsx
+++ b/src/components/CardList/card-list.jsx
@@ -54,19 +54,29 @@ export class CardList extends Component {
   }
 
   /**
-   * Take a suggestion from a CDS service based on action on from a card. Also pings the analytics endpoint (if any) of the
-   * CDS service to notify that a suggestion was taken
+   * Take a suggestion from a CDS service based on action on from a card. Also pings the feedback
+   * endpoint of the CDS service to notify that a suggestion was taken.
    * @param {*} suggestion - CDS service-defined suggestion to take based on CDS Hooks specification
-   * @param {*} url - CDS service endpoint URL
+   * @param {*} cardUUID - UUID of the card containing the suggestion
+   * @param {*} serviceUrl - CDS service endpoint URL
    */
-  takeSuggestion(suggestion, url) {
+  takeSuggestion(suggestion, cardUUID, serviceUrl) {
     if (!this.props.isDemoCard) {
       if (suggestion.label) {
-        if (suggestion.uuid) {
+        if (suggestion.uuid && cardUUID) {
           axios({
             method: 'POST',
-            url: `${url}/analytics/${suggestion.uuid}`,
-            data: {},
+            url: `${serviceUrl}/feedback`,
+            data: {
+              card: cardUUID,
+              outcome: 'accepted',
+              acceptedSuggestions: [
+                {
+                  id: suggestion.uuid,
+                },
+              ],
+              outcomeTimestamp: new Date().toISOString(),
+            },
           });
         }
         this.props.takeSuggestion(suggestion);
@@ -240,7 +250,7 @@ export class CardList extends Component {
           suggestionsSection = card.suggestions.map((item, ind) => (
             <Button
               key={ind}
-              onClick={() => this.takeSuggestion(item, card.serviceUrl)}
+              onClick={() => this.takeSuggestion(item, card.uuid, card.serviceUrl)}
               text={item.label}
               variant={Button.Opts.Variants.EMPHASIS}
             />

--- a/src/components/CardList/card-list.jsx
+++ b/src/components/CardList/card-list.jsx
@@ -68,14 +68,18 @@ export class CardList extends Component {
             method: 'POST',
             url: `${serviceUrl}/feedback`,
             data: {
-              card: cardUUID,
-              outcome: 'accepted',
-              acceptedSuggestions: [
+              feedback: [
                 {
-                  id: suggestion.uuid,
+                  card: cardUUID,
+                  outcome: 'accepted',
+                  acceptedSuggestions: [
+                    {
+                      id: suggestion.uuid,
+                    },
+                  ],
+                  outcomeTimestamp: new Date().toISOString(),
                 },
               ],
-              outcomeTimestamp: new Date().toISOString(),
             },
           });
         }

--- a/src/reducers/helpers/services-filter.js
+++ b/src/reducers/helpers/services-filter.js
@@ -27,7 +27,8 @@ export function getCardsFromServices(state, serviceUrls) {
       // Check if the service response for cards is valid and has at least one card
       if (response && Object.keys(response) && response.cards && response.cards.length) {
         response.cards.forEach((card) => {
-          // Adding a serviceUrl property to each card to distinguish which card maps to which CDS Service (for suggestions analytics endpoint)
+          // Adding a serviceUrl property to each card to distinguish which card maps to which
+          // CDS Service (for feedback endpoint)
           totalCards.cards.push({ ...card, serviceUrl: url });
         });
       }

--- a/tests/components/Card/card.test.js
+++ b/tests/components/Card/card.test.js
@@ -117,7 +117,7 @@ describe('Card component', () => {
 
   it('takes a suggestion if there is a label', () => {
     shallowedComponent.find('.suggestions-section').find('Button').at(0).simulate('click', { preventDefault() {} });
-    mockAxios.onPost(`${serviceUrl}/analytics/uuid-example`).reply(200);
+    mockAxios.onPost(`${serviceUrl}/feedback`).reply(200);
     expect(takeSuggestion).toHaveBeenCalledWith(suggestion);
   });
 


### PR DESCRIPTION
Fixes https://github.com/cds-hooks/sandbox/issues/131

Running locally, I received the following payload in a CDS Service:


```json
{
    "card": "b83b20a3-6e9d-4376-8f0b-81949fee375c",
    "outcome": "accepted",
    "acceptedSuggestions": [{
        "id": "89b94ef2-5cbe-4a98-9ba7-b1220d32f169"
    }],
    "outcomeTimestamp": "2020-05-06T18:45:26.828Z"
}
```