### PR TITLE
Allow dismissing a card and selecting an override reason

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6853,6 +6853,11 @@
         }
       }
     },
+    "classlist-polyfill": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz",
+      "integrity": "sha1-k1vC39lFiodrJ5YXUUY4vKqWSi4="
+    },
     "classnames": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
@@ -14677,6 +14682,11 @@
         "object.assign": "^4.1.0"
       }
     },
+    "keycode-js": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/keycode-js/-/keycode-js-2.0.3.tgz",
+      "integrity": "sha512-nGuOQ0zvYQFr0OOBOZS47e/ifsiuNz1pleQIFS+LX+udj3St6AvHpv55MI8DCre6Yg9D2CG/qqWbuAx7iQt9FQ=="
+    },
     "killable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
@@ -21129,6 +21139,67 @@
         "terra-props-table": "^2.24.0"
       }
     },
+    "terra-dropdown-button": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/terra-dropdown-button/-/terra-dropdown-button-1.13.0.tgz",
+      "integrity": "sha512-Xv3hrsQRasqe0yi4uPnD/J+OnwEoQWLSC3ZO9vdCWEE4qZ84nWwvCGTpRxDr+qdYClep3l+OHZTdSqQwGQNpQA==",
+      "requires": {
+        "classnames": "^2.2.5",
+        "focus-trap-react": "^6.0.0",
+        "keycode-js": "^2.0.1",
+        "prop-types": "^15.5.8",
+        "terra-hookshot": "^5.0.0",
+        "terra-mixins": "^1.35.0"
+      },
+      "dependencies": {
+        "focus-trap": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-4.0.2.tgz",
+          "integrity": "sha512-HtLjfAK7Hp2qbBtLS6wEznID1mPT+48ZnP2nkHzgjpL4kroYHg0CdqJ5cTXk+UO5znAxF5fRUkhdyfgrhh8Lzw==",
+          "requires": {
+            "tabbable": "^3.1.2",
+            "xtend": "^4.0.1"
+          }
+        },
+        "focus-trap-react": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-6.0.0.tgz",
+          "integrity": "sha512-mvEYxmP75PMx0vOqoIAmJHO/qUEvdTAdz6gLlEZyxxODnuKQdnKea2RWTYxghAPrV+ibiIq2o/GTSgQycnAjcw==",
+          "requires": {
+            "focus-trap": "^4.0.2"
+          }
+        },
+        "react-onclickoutside": {
+          "version": "6.9.0",
+          "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.9.0.tgz",
+          "integrity": "sha512-8ltIY3bC7oGhj2nPAvWOGi+xGFybPNhJM0V1H8hY/whNcXgmDeaeoCMPPd8VatrpTsUWjb/vGzrmu6SrXVty3A=="
+        },
+        "tabbable": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-3.1.2.tgz",
+          "integrity": "sha512-wjB6puVXTYO0BSFtCmWQubA/KIn7Xvajw0x0l6eJUudMG/EAiJvIUnyNX6xO4NpGrJ16lbD0eUseB9WxW0vlpQ=="
+        },
+        "terra-hookshot": {
+          "version": "5.27.0",
+          "resolved": "https://registry.npmjs.org/terra-hookshot/-/terra-hookshot-5.27.0.tgz",
+          "integrity": "sha512-aDNc7A6n1BGUyBFm5s1hwyurBIvmGhNi8PLy7+yQwNKcntfAB7nc3G+Wlz6Np3wWCgfqs2Fkab+6czYyZexA5g==",
+          "requires": {
+            "classlist-polyfill": "^1.2.0",
+            "classnames": "^2.2.5",
+            "keycode-js": "^2.0.1",
+            "prop-types": "^15.5.8",
+            "react-onclickoutside": "^6.7.1",
+            "react-portal": "^4.1.2",
+            "resize-observer-polyfill": "^1.4.1"
+          }
+        },
+        "terra-mixins": {
+          "version": "1.35.0",
+          "resolved": "https://registry.npmjs.org/terra-mixins/-/terra-mixins-1.35.0.tgz",
+          "integrity": "sha512-8IoAVHszSDovYVjurUF4zpDhiD4NAmOkVlOsEs1MB6V+mfm5xuZ9kCSexL5F6h0Ndyo36fKpubkYBKBpBHY5Lw=="
+        }
+      }
+    },
     "terra-form": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/terra-form/-/terra-form-2.5.0.tgz",
@@ -21286,7 +21357,29 @@
             "resize-observer-polyfill": "^1.4.1",
             "terra-button": "^2.0.0",
             "terra-doc-template": "^1.0.0",
-            "terra-form-input": "^1.0.0"
+            "terra-form-input": "^1.0.0",
+            "terra-form-select": "^4.0.0"
+          },
+          "dependencies": {
+            "terra-form-select": {
+              "version": "4.26.0",
+              "resolved": "https://registry.npmjs.org/terra-form-select/-/terra-form-select-4.26.0.tgz",
+              "integrity": "sha512-SFUUlQnY1cbImsvHdLHscEBG62Ad95B6Lr/1+Hi6EwJRwd/H0nfFUci5WNiUuFYtza7HTXPq/Xr60xVihNpnYQ==",
+              "requires": {
+                "classnames": "^2.2.5",
+                "prop-types": "^15.5.8",
+                "react-lifecycles-compat": "^3.0.2",
+                "terra-doc-template": "^1.23.0",
+                "terra-form-field": "^2.33.0",
+                "terra-hookshot": "^4.0.0",
+                "terra-mixins": "^1.24.0"
+              }
+            },
+            "terra-mixins": {
+              "version": "1.35.0",
+              "resolved": "https://registry.npmjs.org/terra-mixins/-/terra-mixins-1.35.0.tgz",
+              "integrity": "sha512-8IoAVHszSDovYVjurUF4zpDhiD4NAmOkVlOsEs1MB6V+mfm5xuZ9kCSexL5F6h0Ndyo36fKpubkYBKBpBHY5Lw=="
+            }
           }
         },
         "terra-icon": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "terra-clinical-error-view": "^1.4.0",
     "terra-content-container": "^2.4.0",
     "terra-date-picker": "^2.5.0",
+    "terra-dropdown-button": "^1.13.0",
     "terra-dialog": "^1.0.0",
     "terra-form": "^2.4.0",
     "terra-form-checkbox": "^2.2.0",

--- a/src/actions/action-types.js
+++ b/src/actions/action-types.js
@@ -70,6 +70,7 @@ export const TRIGGER_ORDER_SIGN = 'TRIGGER_ORDER_SIGN';
 
 // Suggestions and apps
 export const TAKE_SUGGESTION = 'TAKE_SUGGESTION';
+export const DISMISS_CARD = 'DISMISS_CARD';
 export const LAUNCH_SMART_APP = 'LAUNCH_SMART_APP';
 
 export const EXPLICIT_HOOK_TRIGGER = 'EXPLICIT_HOOK_TRIGGER ';

--- a/src/actions/service-exchange-actions.js
+++ b/src/actions/service-exchange-actions.js
@@ -34,6 +34,14 @@ export function storeLaunchContext({ url, appContext, remappedUrl }) {
   };
 }
 
+export function dismissCard({ serviceUrl, cardUUID }) {
+  return {
+    type: types.DISMISS_CARD,
+    serviceUrl,
+    cardUUID,
+  };
+}
+
 export const createExchangeRound = (
   exchangeRound,
   currentScreen,

--- a/src/components/CardList/card-list.jsx
+++ b/src/components/CardList/card-list.jsx
@@ -95,6 +95,10 @@ export class CardList extends Component {
   }
 
   dismissCard(serviceUrl, cardUUID, reason) {
+    if (reason) {
+      console.log(`Received reason: ${reason}`);
+    }
+
     store.dispatch(dismissCard({ serviceUrl, cardUUID }));
   }
 

--- a/src/components/CardList/card-list.jsx
+++ b/src/components/CardList/card-list.jsx
@@ -10,6 +10,7 @@ import axios from 'axios';
 import TerraCard from 'terra-card';
 import Text from 'terra-text';
 import Button from 'terra-button';
+import { Item, SplitButton } from 'terra-dropdown-button';
 
 import styles from './card-list.css';
 import {
@@ -93,8 +94,7 @@ export class CardList extends Component {
     }
   }
 
-  dismissCard(serviceUrl, cardUUID) {
-    console.log(`received card list dismissal for ${serviceUrl} and ${cardUUID}`);
+  dismissCard(serviceUrl, cardUUID, reason) {
     store.dispatch(dismissCard({ serviceUrl, cardUUID }));
   }
 
@@ -303,18 +303,47 @@ export class CardList extends Component {
 
         let dismissSection;
         if (card.uuid) {
-          dismissSection = (
-            <div key="dismiss">
-              <Button
-                title="Dismiss Card"
-                onClick={() => {
-                  this.dismissCard(card.serviceUrl, card.uuid);
+          const { overrideReasons } = card;
+          if (overrideReasons) {
+            console.log(`override reasons are ${JSON.stringify(overrideReasons)}`);
+            const items = overrideReasons.map((reason) => (
+              <Item
+                label={`Override: ${reason.display}`}
+                onSelect={() => {
+                  this.dismissCard(card.serviceUrl, card.uuid, reason);
                 }}
-                variant="neutral"
-                text="Dismiss"
               />
-            </div>
-          );
+            ));
+
+            dismissSection = (
+              <div key="dismiss">
+                <hr />
+                <SplitButton
+                  primaryOptionLabel="Dismiss"
+                  onSelect={() => {
+                    this.dismissCard(card.serviceUrl, card.uuid);
+                  }}
+                  variant="neutral"
+                >
+                  {items}
+                </SplitButton>
+              </div>
+            );
+          } else {
+            dismissSection = (
+              <div key="dismiss">
+                <hr />
+                <Button
+                  title="Dismiss Card"
+                  onClick={() => {
+                    this.dismissCard(card.serviceUrl, card.uuid);
+                  }}
+                  variant="neutral"
+                  text="Dismiss"
+                />
+              </div>
+            );
+          }
         }
 
         const classes = cx(

--- a/src/components/CardList/card-list.jsx
+++ b/src/components/CardList/card-list.jsx
@@ -17,6 +17,9 @@ import {
   getCardsFromServices,
 } from '../../reducers/helpers/services-filter';
 
+import store from '../../store/store';
+import { dismissCard } from '../../actions/service-exchange-actions';
+
 const propTypes = {
   /**
    * A boolean to determine if the context of this component is under the Demo Card feature of the Sandbox, or in the actual
@@ -88,6 +91,11 @@ export class CardList extends Component {
         console.error('There was no label on this suggestion', suggestion);
       }
     }
+  }
+
+  dismissCard(serviceUrl, cardUUID) {
+    console.log(`received card list dismissal for ${serviceUrl} and ${cardUUID}`);
+    store.dispatch(dismissCard({ serviceUrl, cardUUID }));
   }
 
   /**
@@ -293,6 +301,22 @@ export class CardList extends Component {
           });
         }
 
+        let dismissSection;
+        if (card.uuid) {
+          dismissSection = (
+            <div key="dismiss">
+              <Button
+                title="Dismiss Card"
+                onClick={() => {
+                  this.dismissCard(card.serviceUrl, card.uuid);
+                }}
+                variant="neutral"
+                text="Dismiss"
+              />
+            </div>
+          );
+        }
+
         const classes = cx(
           styles['decision-card'],
           styles.alert,
@@ -317,6 +341,12 @@ export class CardList extends Component {
             <div className={styles['links-section']}>
               {' '}
               {linksSection}
+              {' '}
+            </div>
+            {' '}
+            <div className={styles['dismiss-section']}>
+              {' '}
+              {dismissSection}
               {' '}
             </div>
             {' '}

--- a/src/components/MessagePanel/message-panel.jsx
+++ b/src/components/MessagePanel/message-panel.jsx
@@ -77,8 +77,8 @@ class MessagePanel extends Component {
 
   isActionableMessage(event) {
     // Ignore the event, if it doesn't meet our expectations.
-    if (!event.data) return false;
-    if ((event.data.source || "").startsWith('react-devtools-')) return false;
+    if (!event.data) { return false; }
+    if ((event.data.source || '').startsWith('react-devtools-')) { return false; }
 
     if (!event.data.messageId) {
       console.warn('Message has no messageId.');

--- a/src/reducers/helpers/services-filter.js
+++ b/src/reducers/helpers/services-filter.js
@@ -19,14 +19,20 @@ export function getServicesByHook(hook, services) {
  */
 export function getCardsFromServices(state, serviceUrls) {
   const totalCards = { cards: [] };
-  const { exchanges } = state.serviceExchangeState;
+  const { exchanges, hiddenCards } = state.serviceExchangeState;
   serviceUrls.forEach((url) => {
     // Check if there is a service exchange (request and response) for this service ID url
     if (exchanges[url]) {
       const { response } = exchanges[url];
+      const hiddenUUIDs = hiddenCards[url];
+
       // Check if the service response for cards is valid and has at least one card
       if (response && Object.keys(response) && response.cards && response.cards.length) {
         response.cards.forEach((card) => {
+          // Skip adding if the card has been dismissed
+          if (card.uuid && hiddenUUIDs.includes(card.uuid)) {
+            return;
+          }
           // Adding a serviceUrl property to each card to distinguish which card maps to which
           // CDS Service (for feedback endpoint)
           totalCards.cards.push({ ...card, serviceUrl: url });

--- a/src/reducers/service-exchange-reducers.js
+++ b/src/reducers/service-exchange-reducers.js
@@ -54,6 +54,7 @@ const serviceExchangeReducers = (state = initialState, action) => {
         break;
       }
 
+      // Dismiss a card from the current view
       case types.DISMISS_CARD: {
         return {
           ...state,

--- a/src/reducers/service-exchange-reducers.js
+++ b/src/reducers/service-exchange-reducers.js
@@ -4,6 +4,7 @@ const initialState = {
   selectedService: '',
   exchanges: {},
   launchLinks: {},
+  hiddenCards: {},
 };
 
 const serviceExchangeReducers = (state = initialState, action) => {
@@ -22,6 +23,10 @@ const serviceExchangeReducers = (state = initialState, action) => {
                 responseStatus: action.responseStatus,
                 exchangeRound: action.exchangeRound,
               },
+            },
+            hiddenCards: {
+              ...state.hiddenCards,
+              [action.url]: [],
             },
           };
         }
@@ -49,12 +54,26 @@ const serviceExchangeReducers = (state = initialState, action) => {
         break;
       }
 
+      case types.DISMISS_CARD: {
+        return {
+          ...state,
+          hiddenCards: {
+            ...state.hiddenCards,
+            [action.serviceUrl]: [
+              ...(state.hiddenCards[action.serviceUrl] || []),
+              action.cardUUID,
+            ],
+          },
+        };
+      }
+
       // Remove any CDS Service exchanges from the store
       case types.RESET_SERVICES: {
         return {
           ...state,
           selectedService: '',
           exchanges: {},
+          hiddenCards: {},
         };
       }
 
@@ -68,10 +87,14 @@ const serviceExchangeReducers = (state = initialState, action) => {
         if (state.exchanges[action.service]) {
           const exchangesCopy = JSON.parse(JSON.stringify(state.exchanges));
           delete exchangesCopy[action.service];
+
+          const hiddenCardsCopy = JSON.parse(JSON.stringify(state.hiddenCards));
+          delete hiddenCardsCopy[action.service];
           return {
             ...state,
             exchanges: exchangesCopy,
             selectedService: state.selectedService === action.service ? '' : state.selectedService,
+            hiddenCards: hiddenCardsCopy,
           };
         }
         break;

--- a/tests/actions/service-exchange-actions.test.js
+++ b/tests/actions/service-exchange-actions.test.js
@@ -27,4 +27,17 @@ describe('Service Exchange Actions', () => {
 
     expect(actions.selectService(service)).toMatchObject(expectedAction);
   });
+
+  it('creates an action to dismiss a card', () => {
+    const serviceUrl = 'http://example.com/cds-services/id-1';
+    const cardUUID = '1';
+
+    const expectedAction = {
+      type: types.DISMISS_CARD,
+      serviceUrl,
+      cardUUID
+    }
+
+    expect(actions.dismissCard({serviceUrl, cardUUID})).toMatchObject(expectedAction);
+  });
 });

--- a/tests/reducers/helpers/services-filter.test.js
+++ b/tests/reducers/helpers/services-filter.test.js
@@ -57,16 +57,18 @@ describe('Services Filters', () => {
           [emptyCardsExchange]: { response: {cards: []} },
           [completeServiceExchange]: {
             response: {
-              cards: [{ summary: 'test' }],
+              cards: [{ uuid: '1', summary: 'test' }],
             },
           },
           [exampleServiceExchange]: {
             response: {
-              cards: [{ summary: 'another-test' }],
+              cards: [{ uuid: '2', summary: 'another-test' }, { uuid: '3', summary: 'third-test' }],
             },
           },
         },
         hiddenCards: {
+          [completeServiceExchange]: [],
+          [exampleServiceExchange]: ['3']
         }
       },
     };

--- a/tests/reducers/helpers/services-filter.test.js
+++ b/tests/reducers/helpers/services-filter.test.js
@@ -66,6 +66,8 @@ describe('Services Filters', () => {
             },
           },
         },
+        hiddenCards: {
+        }
       },
     };
     mockStore = configureStore([])(testStore);

--- a/tests/reducers/service-exchange-reducers.test.js
+++ b/tests/reducers/service-exchange-reducers.test.js
@@ -10,7 +10,8 @@ describe('Services Exchange Reducers', () => {
     state = {
       selectedService: '',
       exchanges: {},
-      launchLinks: {}
+      launchLinks: {},
+      hiddenCards: {},
     };
     storedExchange = {
       request: 'request',
@@ -39,6 +40,9 @@ describe('Services Exchange Reducers', () => {
       const newState = Object.assign({}, state, {
         exchanges: {
           [action.url]: storedExchange
+        },
+        hiddenCards: {
+          [action.url]: []
         }
       });
       expect(reducer(state, action)).toEqual(newState);

--- a/tests/reducers/service-exchange-reducers.test.js
+++ b/tests/reducers/service-exchange-reducers.test.js
@@ -70,12 +70,24 @@ describe('Services Exchange Reducers', () => {
     });
   });
 
+  describe('DISMISS_CARD', () => {
+    it('should add the card uuid to the array of hidden cards when dismissed', () => {
+      state.exchanges[url] = storedExchange;
+      const stateCopy = JSON.parse(JSON.stringify(state));
+      stateCopy.hiddenCards[url] = ['1'];
+      const action = { type: types.DISMISS_CARD, serviceUrl: url, cardUUID: '1' };
+      expect(reducer(state, action)).toEqual(stateCopy);
+    });
+  });
+
   describe('RESET_SERVICES', () => {
     it('should reset the exchanges hash and any selected service', () => {
       state.exchanges[url] = storedExchange;
+      state.hiddenCards[url] = ['1', '2']
       const stateCopy = JSON.parse(JSON.stringify(state));
       stateCopy.exchanges = {};
       stateCopy.selectedService = '';
+      stateCopy.hiddenCards = {};
       const action = { type: types.RESET_SERVICES };
       expect(reducer(state, action)).toEqual(stateCopy);
     });
@@ -108,9 +120,11 @@ describe('Services Exchange Reducers', () => {
     it('should remove stored service exchanges where the exchange URL matches the URL passed in action', () => {
       state.exchanges[url] = storedExchange;
       state.selectedService = url;
+      state.hiddenCards[url] = ['1', '2'];
       const stateCopy = JSON.parse(JSON.stringify(state));
       stateCopy.exchanges =  {};
       stateCopy.selectedService = '';
+      stateCopy.hiddenCards = {};
       const action = {
         type: types.DELETE_SERVICE,
         service: url,


### PR DESCRIPTION
Fixes #130.

## Screenshots

### Service w/o override reasons

Card: 

![Screen Shot 2020-05-12 at 4 53 40 PM](https://user-images.githubusercontent.com/1629720/81749392-2ae3aa00-9471-11ea-8df5-73c4dc8434f5.png)

After clicking Dismiss:

![Screen Shot 2020-05-12 at 4 55 04 PM](https://user-images.githubusercontent.com/1629720/81749509-62525680-9471-11ea-9098-228e05605c06.png)

### Service w/override reasons

Card:

![Screen Shot 2020-05-12 at 4 56 48 PM](https://user-images.githubusercontent.com/1629720/81749628-96c61280-9471-11ea-8593-c522edd751a4.png)

Option exists to dismiss w/o reason or select the drop down as seen here:

![Screen Shot 2020-05-12 at 4 57 33 PM](https://user-images.githubusercontent.com/1629720/81749679-b2311d80-9471-11ea-92c0-66a459883c96.png)

