### PR TITLE
Send feedback when card is dismissed

### DIFF
--- a/src/components/CardList/card-list.jsx
+++ b/src/components/CardList/card-list.jsx
@@ -101,11 +101,14 @@ export class CardList extends Component {
       outcomeTimestamp: new Date().toISOString(),
     };
 
-    if (reason && reason.code && reason.system) {
+    if (reason && reason.code) {
       cardFeedback.overrideReason = {
         code: reason.code,
-        system: reason.system,
       };
+
+      if (reason.system) {
+        cardFeedback.overrideReason.system = reason.system;
+      }
     }
 
     this.sendFeedback(serviceUrl, cardFeedback);

--- a/src/components/CardList/card-list.jsx
+++ b/src/components/CardList/card-list.jsx
@@ -11,6 +11,7 @@ import TerraCard from 'terra-card';
 import Text from 'terra-text';
 import Button from 'terra-button';
 import { Item, SplitButton } from 'terra-dropdown-button';
+import generateJWT from '../../retrieve-data-helpers/jwt-generator';
 
 import styles from './card-list.css';
 import {
@@ -68,25 +69,20 @@ export class CardList extends Component {
     if (!this.props.isDemoCard) {
       if (suggestion.label) {
         if (suggestion.uuid && cardUUID) {
-          axios({
-            method: 'POST',
-            url: `${serviceUrl}/feedback`,
-            data: {
-              feedback: [
-                {
-                  card: cardUUID,
-                  outcome: 'accepted',
-                  acceptedSuggestions: [
-                    {
-                      id: suggestion.uuid,
-                    },
-                  ],
-                  outcomeTimestamp: new Date().toISOString(),
-                },
-              ],
-            },
-          });
+          const cardFeedback = {
+            card: cardUUID,
+            outcome: 'accepted',
+            acceptedSuggestions: [
+              {
+                id: suggestion.uuid,
+              },
+            ],
+            outcomeTimestamp: new Date().toISOString(),
+          };
+
+          this.sendFeedback(serviceUrl, cardFeedback);
         }
+
         this.props.takeSuggestion(suggestion);
       } else {
         console.error('There was no label on this suggestion', suggestion);
@@ -95,11 +91,45 @@ export class CardList extends Component {
   }
 
   dismissCard(serviceUrl, cardUUID, reason) {
-    if (reason) {
-      console.log(`Received reason: ${reason}`);
+    if (this.props.isDemoCard) {
+      return;
     }
 
+    const cardFeedback = {
+      card: cardUUID,
+      outcome: 'overridden',
+      outcomeTimestamp: new Date().toISOString(),
+    };
+
+    if (reason && reason.code && reason.system) {
+      cardFeedback.overrideReason = {
+        code: reason.code,
+        system: reason.system,
+      };
+    }
+
+    this.sendFeedback(serviceUrl, cardFeedback);
+
     store.dispatch(dismissCard({ serviceUrl, cardUUID }));
+  }
+
+  sendFeedback(serviceUrl, cardFeedback) {
+    const feedbackEndpoint = `${serviceUrl}/feedback`;
+    const signedPrivateJWT = generateJWT(feedbackEndpoint);
+
+    axios({
+      method: 'POST',
+      url: feedbackEndpoint,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${signedPrivateJWT}`,
+      },
+      data: {
+        feedback: [
+          cardFeedback,
+        ],
+      },
+    });
   }
 
   /**
@@ -309,7 +339,6 @@ export class CardList extends Component {
         if (card.uuid) {
           const { overrideReasons } = card;
           if (overrideReasons) {
-            console.log(`override reasons are ${JSON.stringify(overrideReasons)}`);
             const items = overrideReasons.map((reason) => (
               <Item
                 label={`Override: ${reason.display}`}


### PR DESCRIPTION
Fixes #132 

This change calls the feedback service when a card is dismissed, including override reason if selected.  It also adds the authorization header to include a bearer token for the call.

## Example payloads

Accepting a suggestion: 

```
{
   "feedback":[
      {
         "card":"0ee39951-9dce-41e8-81ee-13c829b6794b",
         "outcome":"accepted",
         "acceptedSuggestions":[
            {
               "id":"83e4cfc3-8ed4-421d-b3ec-7609e6a38125"
            }
         ],
         "outcomeTimestamp":"2020-05-13T20:08:46.365Z"
      }
   ]
}
```

Dismissing a card:
```
{
   "feedback":[
      {
         "card":"3d8589d5-c443-4258-8f0c-80df921f37f3",
         "outcome":"overridden",
         "outcomeTimestamp":"2020-05-13T20:09:50.128Z"
      }
   ]
}
```

Dismissing a card with an override reason:
```
{
   "feedback":[
      {
         "card":"a7dfa21c-adc3-4df6-aab4-671ebef23f50",
         "outcome":"overridden",
         "outcomeTimestamp":"2020-05-13T20:10:12.147Z",
         "overrideReason":{
            "code":"generic-drug-unavailable",
            "system":"http://terminology.cds-hooks.org/CodeSystem/OverrideReasons"
         }
      }
   ]
}
```