### PR TITLE
enable {{context.userId}} in prefetch tempalte

### DIFF
--- a/src/retrieve-data-helpers/service-exchange.js
+++ b/src/retrieve-data-helpers/service-exchange.js
@@ -63,6 +63,7 @@ function completePrefetchTemplate(state, prefetch) {
       patient,
     );
     prefetchTemplate = prefetchTemplate.replace(/{{\s*user\s*}}/g, user);
+    prefetchTemplate = prefetchTemplate.replace(/{{\s*context\.userId\s*}}/g, user);
     prefetchRequests[prefetchKey] = encodeUriParameters(prefetchTemplate);
   });
   return prefetchRequests;


### PR DESCRIPTION
updated the prefetch template to replace {{context.userId}} as described in the spec

Left the previous {{user}} replacement for backwards compatibility