### PR TITLE
Restore .npmrc legacy-peer-deps for eslint peer dep conflict

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
This should let CI build again.