### PR TITLE
FHIR-57316: add wait indicator for services flagged potentiallyLongRunning

### DIFF
--- a/src/actions/action-types.js
+++ b/src/actions/action-types.js
@@ -38,6 +38,10 @@ export const CREATE_EXCHANGE_ROUND = 'CREATE_EXCHANGE_ROUND';
 export const SELECT_SERVICE_CONTEXT = 'SELECT_SERVICE_CONTEXT';
 export const STORE_SERVICE_EXCHANGE = 'STORE_SERVICE_EXCHANGE';
 export const STORE_LAUNCH_LINK = 'STORE_LAUNCH_LINK';
+// In-flight tracking so the UI can show a spinner for services that
+// advertise the experimental "long-running" discovery extension.
+export const SERVICE_EXCHANGE_PENDING = 'SERVICE_EXCHANGE_PENDING';
+export const SERVICE_EXCHANGE_DONE = 'SERVICE_EXCHANGE_DONE';
 
 // Misc UI actions
 export const SET_LOADING_STATUS = 'SET_LOADING_STATUS';

--- a/src/actions/service-exchange-actions.js
+++ b/src/actions/service-exchange-actions.js
@@ -64,3 +64,11 @@ export function selectService(service) {
     service,
   };
 }
+
+export function markServiceExchangePending(url) {
+  return { type: types.SERVICE_EXCHANGE_PENDING, url };
+}
+
+export function markServiceExchangeDone(url) {
+  return { type: types.SERVICE_EXCHANGE_DONE, url };
+}

--- a/src/components/CardList/card-list.jsx
+++ b/src/components/CardList/card-list.jsx
@@ -17,8 +17,16 @@ import ButtonGroup from '@mui/material/ButtonGroup';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
+import LinearProgress from '@mui/material/LinearProgress';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+
+// Experimental CDS Hooks discovery extension key. A service that advertises
+// this in its discovery document is signalling "expect a noticeable wait" -
+// the UI renders a spinner while the request is in flight instead of the
+// usual empty state.
+const LONG_RUNNING_EXTENSION_URL = 'https://cds-hooks.org/experimental/long-running';
 import generateJWT from '../../retrieve-data-helpers/jwt-generator';
 
 import styles from './card-list.css';
@@ -52,6 +60,11 @@ const propTypes = {
    * JSON structure allowing mapping Card links to URLs with SMART launch contexts.
    */
   launchLinks: PropTypes.object,
+  /**
+   * True when a configured service that advertised the long-running
+   * discovery extension is currently awaiting a response.
+   */
+  awaitingLongRunning: PropTypes.bool,
 };
 
 /**
@@ -462,6 +475,35 @@ export class CardList extends Component {
         renderedCards.push(builtCard);
       });
     if (renderedCards.length === 0) {
+      // If a service that advertises the long-running discovery extension is
+      // currently in flight, show a wait indicator instead of the empty state -
+      // otherwise the user can't tell "no cards" from "still computing".
+      if (this.props.awaitingLongRunning) {
+        return (
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              padding: '60px 20px',
+              textAlign: 'center',
+            }}
+          >
+            <CircularProgress sx={{ marginBottom: 2 }} />
+            <Typography
+              variant="h6"
+              sx={{ color: '#666', fontWeight: 500, marginBottom: 1 }}
+            >
+              Analyzing patient data&hellip;
+            </Typography>
+            <Typography variant="body2" sx={{ color: '#999', maxWidth: 400 }}>
+              This service advertised that it may take a few seconds to
+              respond. Hold on while it computes.
+            </Typography>
+          </Box>
+        );
+      }
       return (
         <Box
           sx={{
@@ -502,11 +544,25 @@ export class CardList extends Component {
         </Box>
       );
     }
+    // A long-running service is refreshing the data we're already showing.
+    // Surface a thin progress bar above the existing cards so the user knows
+    // fresher results are on the way, without blanking the chart.
+    const refreshIndicator = this.props.awaitingLongRunning ? (
+      <Box sx={{ marginBottom: 1 }}>
+        <LinearProgress />
+        <Typography
+          variant="caption"
+          sx={{ color: '#666', display: 'block', marginTop: 0.5 }}
+        >
+          Re-analyzing patient data&hellip;
+        </Typography>
+      </Box>
+    ) : null;
+
     return (
       <div>
-        {' '}
+        {refreshIndicator}
         {renderedCards}
-        {' '}
       </div>
     );
   }
@@ -514,17 +570,27 @@ export class CardList extends Component {
 
 CardList.propTypes = propTypes;
 
-const mapStateToProps = (state, ownProps) => ({
-  ...ownProps,
-  cardResponses: getCardsFromServices(
-    state,
-    Object.keys(getServicesByHook(
-      state.hookState.currentHook,
-      state.cdsServicesState.configuredServices,
-    )),
-  ),
-  launchLinks: state.serviceExchangeState.launchLinks,
-});
+const mapStateToProps = (state, ownProps) => {
+  const servicesByHook = getServicesByHook(
+    state.hookState.currentHook,
+    state.cdsServicesState.configuredServices,
+  );
+  const pending = state.serviceExchangeState.pending || {};
+  // True iff any currently in-flight service for this hook declared itself
+  // long-running in its discovery document.
+  const awaitingLongRunning = Object.entries(servicesByHook).some(
+    ([url, service]) => pending[url]
+      && service
+      && service.extension
+      && service.extension[LONG_RUNNING_EXTENSION_URL],
+  );
+  return {
+    ...ownProps,
+    cardResponses: getCardsFromServices(state, Object.keys(servicesByHook)),
+    launchLinks: state.serviceExchangeState.launchLinks,
+    awaitingLongRunning,
+  };
+};
 
 export default connect(
   mapStateToProps,

--- a/src/reducers/service-exchange-reducers.js
+++ b/src/reducers/service-exchange-reducers.js
@@ -5,6 +5,8 @@ const initialState = {
   exchanges: {},
   launchLinks: {},
   hiddenCards: {},
+  // Map of url -> true while a CDS POST is in flight. Cleared on completion.
+  pending: {},
 };
 
 const serviceExchangeReducers = (state = initialState, action) => {
@@ -31,6 +33,21 @@ const serviceExchangeReducers = (state = initialState, action) => {
           };
         }
         break;
+      }
+
+      case types.SERVICE_EXCHANGE_PENDING: {
+        if (!action.url) break;
+        return {
+          ...state,
+          pending: { ...state.pending, [action.url]: true },
+        };
+      }
+
+      case types.SERVICE_EXCHANGE_DONE: {
+        if (!action.url || !state.pending[action.url]) break;
+        const nextPending = { ...state.pending };
+        delete nextPending[action.url];
+        return { ...state, pending: nextPending };
       }
 
       case types.STORE_LAUNCH_LINK: {
@@ -75,6 +92,7 @@ const serviceExchangeReducers = (state = initialState, action) => {
           selectedService: '',
           exchanges: {},
           hiddenCards: {},
+          pending: {},
         };
       }
 
@@ -112,6 +130,7 @@ const serviceExchangeReducers = (state = initialState, action) => {
           selectedService: '',
           exchanges: {},
           hiddenCards: {},
+          pending: {},
         };
       }
 

--- a/src/retrieve-data-helpers/service-exchange.js
+++ b/src/retrieve-data-helpers/service-exchange.js
@@ -4,6 +4,8 @@ import retrieveLaunchContext from './launch-context-retrieval';
 import {
   storeExchange,
   storeLaunchContext,
+  markServiceExchangePending,
+  markServiceExchangeDone,
 } from '../actions/service-exchange-actions';
 import { productionClientId, allScopes } from '../config/fhir-config';
 import generateJWT from './jwt-generator';
@@ -311,15 +313,20 @@ function callServices(dispatch, state, url, context, exchangeRound = 0) {
 
   const serviceDefinition = state.cdsServicesState.configuredServices[url];
 
-  const sendRequest = () => axios({
-    method: 'post',
-    url,
-    data: request,
-    headers: {
-      Accept: 'application/json',
-      Authorization: `Bearer ${generateJWT(url)}`,
-    },
-  });
+  const sendRequest = () => {
+    // Mark this service as in-flight so the UI can render a wait indicator
+    // for services that advertise the long-running discovery extension.
+    dispatch(markServiceExchangePending(url));
+    return axios({
+      method: 'post',
+      url,
+      data: request,
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Bearer ${generateJWT(url)}`,
+      },
+    });
+  };
 
   const dispatchResult = (result) => {
     if (result.data && Object.keys(result.data).length) {
@@ -364,7 +371,8 @@ function callServices(dispatch, state, url, context, exchangeRound = 0) {
     }
     return sendRequest()
       .then(dispatchResult)
-      .catch(dispatchErrors);
+      .catch(dispatchErrors)
+      .finally(() => dispatch(markServiceExchangeDone(url)));
   });
 }
 


### PR DESCRIPTION
## Summary

Adds a UI wait indicator for CDS services that may take a noticeable time to respond (e.g. LLM-backed or heavy-analysis services). Today the sandbox waits silently, so the user can't tell "no cards" from "still computing".

A service opts in via an OPTIONAL `potentiallyLongRunning: true` boolean in its discovery document (proposed as STU). Services that don't set it are unaffected.

## UI behaviour

- **No prior cards:** a spinner + "Analyzing patient data…" replaces the empty state while the service is in flight.
- **Refreshing existing cards:** a thin progress bar + "Re-analyzing patient data…" appears above the cards, which stay visible so the chart never blanks.

Both only show when a configured service for the current hook is awaiting a response **and** advertised `potentiallyLongRunning`.

## Mechanism

- `SERVICE_EXCHANGE_PENDING` / `SERVICE_EXCHANGE_DONE` actions dispatched around the axios POST (`.finally()`, so it clears on success and failure).
- Reducer tracks a `pending: { [url]: true }` map, cleared on `RESET_SERVICES` and `GET_PATIENT_SUCCESS`.
- `CardList` correlates pending URLs against `service.potentiallyLongRunning` to derive `awaitingLongRunning`.

## Test plan

- [x] Service with `potentiallyLongRunning: true` in discovery: spinner on first load, refresh bar on later loads.
- [x] Service without it: no change vs master.
- [x] Reset services / switch patients mid-call: pending state clears cleanly.

No Jest tests in this draft - happy to add reducer tests once the design is accepted.
